### PR TITLE
Full cleanup of fusion code, including:

### DIFF
--- a/encoder_helpers.py
+++ b/encoder_helpers.py
@@ -223,44 +223,107 @@ def reconstruct_2d_grid(N: int) -> tuple:
             return N // w, w
     return N, 1
 
-def generate_spatial_fusion_mask(N: int, num_sources: int, method: str, block_size: int = 2, dither_ratio: float = 0.5, device: str = "cpu") -> torch.Tensor:
+SPATIAL_FUSION_METHODS = {"spatial-checkerboard", "spatial-block-interleave", "spatial-dither-random"}
+VISUAL_FUSION_METHODS = SPATIAL_FUSION_METHODS | {"linear"}
+
+
+def generate_spatial_fusion_mask(N: int, num_sources: int, method: str, block_size: int = 2, dither_ratio: float = 0.5, device: str = "cpu", seed: int = 0) -> torch.Tensor:
     """
-    Generates a deterministic 1D token index mapping array corresponding to a source image index.
+    Generates a seeded 1D token index mapping array corresponding to a source image index.
     """
-    if num_sources <= 1:
+    if N < 0:
+        raise ValueError("Visual token count cannot be negative.")
+    if num_sources < 1:
+        raise ValueError("Visual fusion requires at least one source.")
+    if method not in SPATIAL_FUSION_METHODS:
+        raise ValueError(f"Unsupported spatial fusion method: {method}")
+    if method == "spatial-block-interleave" and block_size < 1:
+        raise ValueError("Visual block size must be at least 1.")
+    if method == "spatial-dither-random" and not 0.0 <= dither_ratio <= 1.0:
+        raise ValueError("Dither ratio must be between 0.0 and 1.0.")
+    if not 0 <= seed <= 0xffffffffffffffff:
+        raise ValueError("Visual fusion seed must be between 0 and 18446744073709551615.")
+    if num_sources == 1:
         return torch.zeros(N, dtype=torch.long, device=device)
 
     h, w = reconstruct_2d_grid(N)
+    rows = torch.arange(h, device=device).unsqueeze(1)
+    columns = torch.arange(w, device=device).unsqueeze(0)
 
     if method == "spatial-checkerboard":
-        mask = torch.zeros(N, dtype=torch.long, device=device)
-        for i in range(N):
-            r = i // w
-            c = i % w
-            mask[i] = (r + c) % num_sources
-        return mask
+        return ((rows + columns) % num_sources).flatten()
+    if method == "spatial-block-interleave":
+        return ((rows // block_size + columns // block_size) % num_sources).flatten()
 
-    elif method == "spatial-block-interleave":
-        mask = torch.zeros(N, dtype=torch.long, device=device)
-        for i in range(N):
-            r = i // w
-            c = i % w
-            block_r = r // block_size
-            block_c = c // block_size
-            mask[i] = (block_r + block_c) % num_sources
-        return mask
+    generator = torch.Generator(device=device).manual_seed(seed)
+    random = torch.rand(N, generator=generator, device=device)
+    other_sources = 1 + ((rows + columns) % (num_sources - 1)).flatten()
+    return torch.where(random < dither_ratio, 0, other_sources)
 
-    elif method == "spatial-dither-random":
-        g = torch.Generator(device=device)
-        g.manual_seed(42)  # Deterministic seed to prevent shifting patterns on every generation run
-        rands = torch.rand(N, generator=g, device=device)
-        if num_sources == 2:
-            return torch.where(rands < dither_ratio, 0, 1)
-        else:
-            return (rands * num_sources).long()
 
-    else:
-        return torch.zeros(N, dtype=torch.long, device=device)
+def _visual_fusion_mask(config, N, num_sources, mask_device, output_device, mask_cache):
+    method = config.get("visual_fusion_method", "spatial-checkerboard")
+    block_size = config.get("visual_block_size", 2)
+    dither_ratio = config.get("dither_ratio", 0.5)
+    seed = config.get("seed", 0)
+    key = (N, num_sources, method, block_size, dither_ratio, seed)
+    if key not in mask_cache:
+        mask_cache[key] = generate_spatial_fusion_mask(N, num_sources, method, block_size, dither_ratio, mask_device, seed)
+    return mask_cache[key].to(output_device)
+
+
+def fuse_visual_token_sources(sources, visual_fusion_config, mask_device, mask_cache=None, expected_length=None):
+    if not sources:
+        raise ValueError("Visual fusion requires at least one visual token source.")
+
+    method = visual_fusion_config.get("visual_fusion_method", "spatial-checkerboard")
+    if method not in VISUAL_FUSION_METHODS:
+        raise ValueError(f"Unsupported visual fusion method: {method}")
+    if any(source.ndim != 2 for source in sources):
+        raise ValueError("Visual fusion sources must have shape [tokens, dimensions].")
+    if any(source.shape[1] != sources[0].shape[1] for source in sources[1:]):
+        raise ValueError("Visual fusion sources must have matching embedding dimensions.")
+    if any(source.device != sources[0].device for source in sources[1:]):
+        raise ValueError("Visual fusion sources must be on the same device.")
+
+    max_length = max(source.shape[0] for source in sources)
+    if expected_length is not None and max_length != expected_length:
+        raise ValueError(f"Visual token layout mismatch: expected {expected_length} tokens, received {max_length}.")
+
+    output_dtype = sources[0].dtype
+    compute_float = method == "linear" or any(source.shape[0] != max_length for source in sources)
+    aligned = []
+    for source in sources:
+        value = source.to(dtype=torch.float32) if compute_float else source
+        if value.shape[0] != max_length:
+            value = F.interpolate(value.transpose(0, 1).unsqueeze(0), size=max_length, mode="linear", align_corners=False).squeeze(0).transpose(0, 1)
+        aligned.append(value)
+
+    stacked = torch.stack(aligned, dim=1)
+    if method == "linear":
+        return stacked.mean(dim=1).to(dtype=output_dtype)
+
+    if mask_cache is None:
+        mask_cache = {}
+    mask = _visual_fusion_mask(visual_fusion_config, max_length, len(sources), mask_device, stacked.device, mask_cache)
+    fused = torch.take_along_dim(stacked, mask[:, None, None], dim=1).squeeze(1)
+    return fused.to(dtype=output_dtype)
+
+
+def fuse_deepstack_layers(deepstack_tensors, visual_fusion_config, device, mask_cache, expected_length):
+    active_keys = sorted(deepstack_tensors)
+    if not active_keys:
+        return None
+
+    num_layers = len(deepstack_tensors[active_keys[0]])
+    if any(len(deepstack_tensors[key]) != num_layers for key in active_keys[1:]):
+        raise ValueError("Visual fusion sources produced different DeepStack layer counts.")
+
+    blended = []
+    for layer in range(num_layers):
+        sources = [deepstack_tensors[key][layer].to(device=device) for key in active_keys]
+        blended.append(fuse_visual_token_sources(sources, visual_fusion_config, device, mask_cache, expected_length))
+    return blended
 
 
 # =====================================================================
@@ -308,11 +371,10 @@ def save_blended_visual_embeddings(
     if not save_name.endswith(".safetensors"):
         save_name += ".safetensors"
 
-    try:
-        embed_paths = folder_paths.get_folder_paths("embeddings")
-        embeddings_dir = embed_paths[0] if embed_paths else "models/embeddings"
-    except Exception:
-        embeddings_dir = "models/embeddings"
+    embed_paths = folder_paths.get_folder_paths("embeddings")
+    if not embed_paths:
+        raise ValueError("No ComfyUI embeddings directory is configured.")
+    embeddings_dir = embed_paths[0]
 
     os.makedirs(embeddings_dir, exist_ok=True)
     full_save_path = os.path.join(embeddings_dir, save_name)
@@ -331,7 +393,8 @@ def evaluate_conditioning_consensus_blend(
     visual_ranges: dict = None,
     embedding_key: str = "qwen3vl_8b",
     clip = None,
-    tokens_dict: dict = None
+    tokens_dict: dict = None,
+    mask_cache: dict = None,
 ) -> tuple:
     """
     Decoupled blending engine focused entirely on isolated visual token spatial fusion.
@@ -339,9 +402,15 @@ def evaluate_conditioning_consensus_blend(
     """
 
     if visual_fusion_config is None:
-        visual_fusion_config = {"visual_fusion_method": "spatial-checkerboard", "visual_block_size": 2, "dither_ratio": 0.5}
+        visual_fusion_config = {"visual_fusion_method": "spatial-checkerboard", "visual_block_size": 2, "dither_ratio": 0.5, "seed": 0}
 
     visual_method = visual_fusion_config.get("visual_fusion_method", "spatial-checkerboard")
+    if visual_method not in VISUAL_FUSION_METHODS:
+        raise ValueError(f"Unsupported visual fusion method: {visual_method}")
+    if visual_ranges is None:
+        raise ValueError("Visual token ranges are required for visual fusion.")
+    if mask_cache is None:
+        mask_cache = {}
 
     active_keys = sorted(list(sequence_tensors.keys()))
     tensors_list = [sequence_tensors[k] for k in active_keys]
@@ -349,80 +418,13 @@ def evaluate_conditioning_consensus_blend(
         return None, None
 
     B = tensors_list[0].shape[0]
-    D = tensors_list[0].shape[2]
-
-    # --- Independent Standalone RAW Visual Embeddings Extraction & Saving ---
-    if visual_fusion_config.get("save_blended_embeds", False) and clip is not None and tokens_dict:
-        try:
-            cond_stage = clip.cond_stage_model
-            clip_model = None
-            if hasattr(cond_stage, "clip") and isinstance(cond_stage.clip, str) and hasattr(cond_stage, cond_stage.clip):
-                clip_model = getattr(cond_stage, cond_stage.clip)
-            elif hasattr(cond_stage, "clip_model"):
-                clip_model = cond_stage.clip_model
-            elif hasattr(cond_stage, "clip_d"):
-                clip_model = cond_stage.clip_d
-            else:
-                clip_model = cond_stage
-
-            raw_visuals = {}
-            for k in active_keys:
-                if k in tokens_dict:
-                    tok = tokens_dict[k]
-                    key_name = next(iter(tok.keys()))
-                    token_list = tok[key_name]
-                    tokens_only = [[t[0] for t in b] for b in token_list]
-                    with torch.inference_mode():
-                        embeds, _, _, embeds_info = clip_model.process_tokens(tokens_only, device)
-
-                    vr = visual_ranges.get(k, (0, 0))
-                    if vr and vr != (0, 0):
-                        v_start, v_end = vr
-                        raw_visuals[k] = embeds[0, v_start:v_end, :].clone().cpu()
-
-            if raw_visuals:
-                max_vis_len_raw = max(v.shape[0] for v in raw_visuals.values())
-                D_raw = next(iter(raw_visuals.values())).shape[1]
-
-                aligned_raw = {}
-                for k, v in raw_visuals.items():
-                    if v.shape[0] != max_vis_len_raw:
-                        v_perm = v.permute(1, 0).unsqueeze(0)
-                        v_interp = torch.nn.functional.interpolate(v_perm, size=max_vis_len_raw, mode='linear', align_corners=False)
-                        v = v_interp.squeeze(0).permute(1, 0)
-                    aligned_raw[k] = v
-
-                if visual_method.startswith("spatial-"):
-                    blended_raw_2d = torch.zeros((max_vis_len_raw, D_raw), device="cpu", dtype=torch.float32)
-                    sources_list = [aligned_raw[k] for k in active_keys if k in aligned_raw]
-
-                    fusion_mask = generate_spatial_fusion_mask(
-                        N=max_vis_len_raw,
-                        num_sources=len(sources_list),
-                        method=visual_method,
-                        block_size=visual_fusion_config.get("visual_block_size", 2),
-                        dither_ratio=visual_fusion_config.get("dither_ratio", 0.5),
-                        device="cpu"
-                    )
-
-                    for i in range(max_vis_len_raw):
-                        src_idx = fusion_mask[i].item()
-                        blended_raw_2d[i] = sources_list[src_idx][i]
-                elif visual_method == "linear":
-                    sources_list = [aligned_raw[k] for k in active_keys if k in aligned_raw]
-                    stacked = torch.stack(sources_list, dim=0)
-                    blended_raw_2d = torch.mean(stacked, dim=0)
-                else:
-                    blended_raw_2d = aligned_raw[active_keys[0]]
-
-                # Save correct raw visual input embeddings [N, D_raw] (e.g. 2560) directly
-                save_blended_visual_embeddings([blended_raw_2d], visual_fusion_config, embedding_key)
-        except Exception as e:
-            logging.error(f"[evaluate_conditioning_consensus_blend] Failed to process and save raw embeddings: {e}", exc_info=True)
+    expected_visual_length = max(end - start for start, end in (visual_ranges.get(key, (0, 0)) for key in active_keys))
+    if expected_visual_length <= 0 or any(visual_ranges.get(key, (0, 0)) == (0, 0) for key in active_keys):
+        raise ValueError("Every visual fusion source must have a valid visual token range.")
 
     C_blended_list = []
     for b in range(B):
-        batch_tensors_dict = {k: sequence_tensors[k][b].to(device=device, dtype=torch.float32) for k in active_keys}
+        batch_tensors_dict = {k: sequence_tensors[k][b].to(device=device) for k in active_keys}
         ref_key = active_keys[0]
 
         prefixes = {}
@@ -431,56 +433,13 @@ def evaluate_conditioning_consensus_blend(
 
         for k in active_keys:
             t = batch_tensors_dict[k]
-            vr = visual_ranges.get(k, (0, 0))
-            if vr is None or vr == (0, 0):
-                prefixes[k] = t
-                visuals[k] = torch.zeros((0, D), device=device, dtype=t.dtype)
-                suffixes[k] = torch.zeros((0, D), device=device, dtype=t.dtype)
-            else:
-                v_start, v_end = vr
-                prefixes[k] = t[:v_start, :]
-                visuals[k] = t[v_start:v_end, :]
-                suffixes[k] = t[v_end:, :]
+            v_start, v_end = visual_ranges[k]
+            prefixes[k] = t[:v_start, :]
+            visuals[k] = t[v_start:v_end, :]
+            suffixes[k] = t[v_end:, :]
 
-        # Splicing of isolated visual blocks
-        active_visuals = {k: v for k, v in visuals.items() if v.shape[0] > 0}
-        if active_visuals and visual_method != "off":
-            max_vis_len = max(v.shape[0] for v in active_visuals.values())
-            aligned_visuals = {}
-            for k, v in active_visuals.items():
-                if v.shape[0] != max_vis_len:
-                    v_perm = v.permute(1, 0).unsqueeze(0)
-                    v_interp = torch.nn.functional.interpolate(v_perm, size=max_vis_len, mode='linear', align_corners=False)
-                    v = v_interp.squeeze(0).permute(1, 0)
-                aligned_visuals[k] = v
-
-            if visual_method.startswith("spatial-"):
-                blended_vis_2d = torch.zeros((max_vis_len, D), device=device, dtype=torch.float32)
-                sources_list = [aligned_visuals[k] for k in active_keys if k in aligned_visuals]
-
-                fusion_mask = generate_spatial_fusion_mask(
-                    N=max_vis_len,
-                    num_sources=len(sources_list),
-                    method=visual_method,
-                    block_size=visual_fusion_config.get("visual_block_size", 2),
-                    dither_ratio=visual_fusion_config.get("dither_ratio", 0.5),
-                    device=device
-                )
-
-                for i in range(max_vis_len):
-                    src_idx = fusion_mask[i].item()
-                    blended_vis_2d[i] = sources_list[src_idx][i]
-
-            elif visual_method == "linear":
-                # Fallback linear average
-                sources_list = [aligned_visuals[k] for k in active_keys if k in aligned_visuals]
-                stacked = torch.stack(sources_list, dim=0)
-                blended_vis_2d = torch.mean(stacked, dim=0)
-            else:
-                # Default fallback to reference image
-                blended_vis_2d = aligned_visuals[ref_key]
-        else:
-            blended_vis_2d = aligned_visuals[ref_key] if active_visuals else torch.zeros((0, D), device=device)
+        sources = [visuals[key] for key in active_keys]
+        blended_vis_2d = fuse_visual_token_sources(sources, visual_fusion_config, device, mask_cache, expected_visual_length)
 
         # Surrounding text (prefixes & suffixes) are kept 100% pure from the reference pass
         blended_prefix = prefixes[ref_key]
@@ -490,6 +449,33 @@ def evaluate_conditioning_consensus_blend(
         C_blended_list.append(torch.cat([blended_prefix, blended_vis_2d, blended_suffix], dim=0))
 
     C_blended = torch.stack(C_blended_list, dim=0).to(dtype=tensors_list[0].dtype, device=tensors_list[0].device)
+
+    if visual_fusion_config.get("save_blended_embeds", False):
+        if clip is None or not tokens_dict:
+            raise ValueError("Saving blended visual embeddings requires the text encoder and source tokens.")
+
+        cond_stage = clip.cond_stage_model
+        if hasattr(cond_stage, "clip") and isinstance(cond_stage.clip, str) and hasattr(cond_stage, cond_stage.clip):
+            clip_model = getattr(cond_stage, cond_stage.clip)
+        elif hasattr(cond_stage, "clip_model"):
+            clip_model = cond_stage.clip_model
+        elif hasattr(cond_stage, "clip_d"):
+            clip_model = cond_stage.clip_d
+        else:
+            clip_model = cond_stage
+
+        raw_visuals = []
+        for key in active_keys:
+            if key not in tokens_dict:
+                raise ValueError(f"Missing source tokens for raw visual embedding {key}.")
+            token_list = tokens_dict[key][next(iter(tokens_dict[key]))]
+            tokens_only = [[token[0] for token in batch] for batch in token_list]
+            embeds, _, _, _ = clip_model.process_tokens(tokens_only, device)
+            v_start, v_end = visual_ranges[key]
+            raw_visuals.append(embeds[0, v_start:v_end, :].clone().cpu())
+
+        blended_raw = fuse_visual_token_sources(raw_visuals, visual_fusion_config, device, mask_cache, expected_visual_length)
+        save_blended_visual_embeddings([blended_raw], visual_fusion_config, embedding_key)
 
     # Pooled output is kept pure from reference pass since text is identical
     ref_key = active_keys[0]

--- a/encoder_nodes.py
+++ b/encoder_nodes.py
@@ -19,10 +19,8 @@ from .encoder_helpers import(
     is_image_token,
     evaluate_formula,
     evaluate_conditioning_formula,
-    reconstruct_2d_grid,
-    generate_spatial_fusion_mask,
-    save_blended_visual_embeddings,
     evaluate_conditioning_consensus_blend,
+    fuse_deepstack_layers,
     blend_text_vectors,
     find_visual_token_range,
     encode_embedding_classical_scaled_bias,
@@ -260,14 +258,15 @@ class UC_VisualFusionConfig(io.ComfyNode):
             inputs=[
                 io.Combo.Input(
                     "visual_fusion_method",
-                    options=["off", "linear", "index-consensus", "similarity-consensus", "spatial-checkerboard", "spatial-block-interleave", "spatial-dither-random"],
+                    options=["off", "linear", "spatial-checkerboard", "spatial-block-interleave", "spatial-dither-random"],
                     default="spatial-checkerboard",
                     tooltip="Method to combine isolated visual tokens. Methods starting with 'spatial-' interleave pure token vectors to keep details perfectly sharp and achieve true fusion instead of filter-like blurring."
                 ),
                 io.Int.Input("visual_block_size", default=2, min=1, max=8, step=1, tooltip="Active for spatial-block-interleave. Size of the spatial token patches to group and switch together."),
-                io.Float.Input("dither_ratio", default=0.5, min=0.0, max=1.0, step=0.01, tooltip="Active for spatial-dither-random. Probability of selecting a token from the first image vs subsequent images."),
+                io.Float.Input("dither_ratio", default=0.5, min=0.0, max=1.0, step=0.01, tooltip="Active for spatial-dither-random. Probability of selecting the first image. Remaining images are selected with a checkerboard pattern."),
                 io.Boolean.Input("save_blended_embeds", default=False, tooltip="Enable to save the blended visual tokens as a standalone .safetensors embedding."),
-                io.String.Input("save_path", default="blended_visual_embeds.safetensors", tooltip="Target filename/path under models/embeddings to save the .safetensors file.")
+                io.String.Input("save_path", default="blended_visual_embeds.safetensors", tooltip="Target filename/path under models/embeddings to save the .safetensors file."),
+                io.Int.Input("seed", default=0, min=0, max=0xffffffffffffffff, control_after_generate=True, tooltip="Seed for the spatial-dither-random pattern.")
             ],
             outputs=[
                 VisualFusionConfig.Output("visual_fusion_config")
@@ -281,12 +280,14 @@ class UC_VisualFusionConfig(io.ComfyNode):
         visual_block_size: int,
         dither_ratio: float,
         save_blended_embeds: bool = False,
-        save_path: str = "blended_visual_embeds.safetensors"
+        save_path: str = "blended_visual_embeds.safetensors",
+        seed: int = 0,
     ) -> io.NodeOutput:
         config = {
             "visual_fusion_method": visual_fusion_method,
             "visual_block_size": visual_block_size,
             "dither_ratio": dither_ratio,
+            "seed": seed,
             "save_blended_embeds": save_blended_embeds,
             "save_path": save_path
         }
@@ -1906,11 +1907,10 @@ class TextEncodeKrea2SystemEditScaledAdv(io.ComfyNode):
         deepstack_dict = {}
         visual_ranges = {}
         tokens_dict = {}
-        ref_cond_dict = None
         last_cond_dict = None
 
         if visual_fusion_config is None:
-            visual_fusion_config = {"visual_fusion_method": "spatial-checkerboard", "visual_block_size": 2, "dither_ratio": 0.5}
+            visual_fusion_config = {"visual_fusion_method": "spatial-checkerboard", "visual_block_size": 2, "dither_ratio": 0.5, "seed": 0}
         visual_method = visual_fusion_config.get("visual_fusion_method", "spatial-checkerboard")
 
         def process_vlm_image(image, res):
@@ -1970,14 +1970,14 @@ class TextEncodeKrea2SystemEditScaledAdv(io.ComfyNode):
             if P_X is not None:
                 pooled_tensors[letter] = P_X
 
-            # Tokenize and find visual token range for isolation blending
-            try:
-                tokens = clip.tokenize(full_prompt, images=[processed_img], skip_template=True)
-                tokens_dict[letter] = tokens
-                vis_start, vis_end = find_visual_token_range(tokens, C_X)
-                visual_ranges[letter] = (vis_start, vis_end)
-            except Exception:
-                visual_ranges[letter] = (0, 0)
+            if visual_method != "off":
+                try:
+                    tokens = clip.tokenize(full_prompt, images=[processed_img], skip_template=True)
+                    tokens_dict[letter] = tokens
+                    vis_start, vis_end = find_visual_token_range(tokens, C_X)
+                    visual_ranges[letter] = (vis_start, vis_end)
+                except Exception as e:
+                    raise ValueError(f"Could not locate the visual token range for image {idx + 1}: {e}") from e
 
             # Extract DeepStack per-layer tensors if present
             if "embeds_info" in cond_X[0][1] and len(cond_X[0][1]["embeds_info"]) > 0:
@@ -1985,11 +1985,10 @@ class TextEncodeKrea2SystemEditScaledAdv(io.ComfyNode):
                 if "deepstack" in extra:
                     deepstack_dict[letter] = extra["deepstack"]
 
-            if idx == 0:
-                ref_cond_dict = cond_X[0][1]
             last_cond_dict = cond_X[0][1]
 
         # Evaluate mathematical formula or consensus on sequence and pooled tensors
+        fusion_mask_cache = {}
         if visual_method != "off":
             device = comfy.model_management.get_torch_device()
 
@@ -1998,7 +1997,7 @@ class TextEncodeKrea2SystemEditScaledAdv(io.ComfyNode):
                 key_name = next(iter(tokens.keys()))
 
             C_blended, P_blended = evaluate_conditioning_consensus_blend(
-                sequence_tensors, pooled_tensors, visual_fusion_config=visual_fusion_config, device=device, visual_ranges=visual_ranges, embedding_key=key_name, clip=clip, tokens_dict=tokens_dict
+                sequence_tensors, pooled_tensors, visual_fusion_config=visual_fusion_config, device=device, visual_ranges=visual_ranges, embedding_key=key_name, clip=clip, tokens_dict=tokens_dict, mask_cache=fusion_mask_cache
             )
         else:
             C_blended, P_blended = evaluate_conditioning_formula(formula, sequence_tensors, pooled_tensors, padding_method=padding_method)
@@ -2006,59 +2005,31 @@ class TextEncodeKrea2SystemEditScaledAdv(io.ComfyNode):
         # Evaluate mathematical formula on DeepStack layers
         deepstack_blended = None
         if deepstack_dict:
-            first_key = next(iter(sequence_tensors.keys()))
-            num_layers = len(deepstack_dict[first_key])
-            max_vis_len = max(ds_list[0].shape[0] for ds_list in deepstack_dict.values())
-
-            deepstack_blended = []
-
-
-            for l in range(num_layers):
-                layer_tensors = {let: ds_list[l] for let, ds_list in deepstack_dict.items()}
-
-                if visual_method != "off":
-                    wrapped_layer_tensors = {let: t.unsqueeze(0) for let, t in layer_tensors.items()}
-                    device = comfy.model_management.get_torch_device()
-                    # DeepStack intermediate layers must be blended recursively. We use linear blending fallback.
-                    C_l_blended, _ = evaluate_conditioning_consensus_blend(
-                        wrapped_layer_tensors, {}, visual_fusion_config={"visual_fusion_method": "linear"}, device=device
-                    )
-                    deepstack_blended.append(C_l_blended.squeeze(0))
-                else:
-                    # Align layer tensors to maximum length
+            if visual_method != "off":
+                expected_visual_length = max(end - start for start, end in visual_ranges.values())
+                deepstack_blended = fuse_deepstack_layers(deepstack_dict, visual_fusion_config, device, fusion_mask_cache, expected_visual_length)
+            else:
+                first_key = next(iter(sequence_tensors.keys()))
+                num_layers = len(deepstack_dict[first_key])
+                max_vis_len = max(ds_list[0].shape[0] for ds_list in deepstack_dict.values())
+                deepstack_blended = []
+                for l in range(num_layers):
+                    layer_tensors = {let: ds_list[l] for let, ds_list in deepstack_dict.items()}
                     aligned_layer_tensors = {}
                     for name, tensor in layer_tensors.items():
                         if tensor.shape[0] < max_vis_len:
                             if padding_method == "interpolate":
                                 tensor_perm = tensor.permute(1, 0).unsqueeze(0)
-                                tensor_interp = F.interpolate(tensor_perm, size=max_vis_len, mode='linear', align_corners=False)
-                                tensor = tensor_interp.squeeze(0).permute(1, 0)
-                            else:  # zero-pad
-                                pad_size = max_vis_len - tensor.shape[0]
-                                padding = torch.zeros((pad_size, tensor.shape[1]), device=tensor.device, dtype=tensor.dtype)
+                                tensor = F.interpolate(tensor_perm, size=max_vis_len, mode="linear", align_corners=False).squeeze(0).permute(1, 0)
+                            else:
+                                padding = torch.zeros((max_vis_len - tensor.shape[0], tensor.shape[1]), device=tensor.device, dtype=tensor.dtype)
                                 tensor = torch.cat([tensor, padding], dim=0)
                         aligned_layer_tensors[name] = tensor
 
-                    safe_dict_layer = {
-                        "__builtins__": {},
-                        "clamp": torch.clamp,
-                        "min": torch.minimum,
-                        "max": torch.maximum,
-                        "abs": torch.abs,
-                    }
-                    for name, t in aligned_layer_tensors.items():
-                        safe_dict_layer[name] = t
-
-                    # Handle classical weighting conversions inside math formula
-                    layer_expression = re.sub(
-                        r"\(\s*([a-zA-Z0-9_]+)\s*:\s*([0-9.-]+)\s*\)",
-                        r"(\1 * \2)",
-                        formula
-                    )
-
+                    safe_dict_layer = {"__builtins__": {}, "clamp": torch.clamp, "min": torch.minimum, "max": torch.maximum, "abs": torch.abs, **aligned_layer_tensors}
+                    layer_expression = re.sub(r"\(\s*([a-zA-Z0-9_]+)\s*:\s*([0-9.-]+)\s*\)", r"(\1 * \2)", formula)
                     try:
-                        layer_blended = eval(layer_expression, safe_dict_layer, {}) # noqa: S307
-                        deepstack_blended.append(layer_blended)
+                        deepstack_blended.append(eval(layer_expression, safe_dict_layer, {}))  # noqa: S307
                     except Exception as e:
                         raise RuntimeError(f"Error evaluating DeepStack math expression at layer {l}: {e}")
 
@@ -2194,11 +2165,10 @@ class TextEncodeEditScaledAdv(io.ComfyNode):
         pooled_tensors = {}
         visual_ranges = {}
         tokens_dict = {}
-        ref_cond_dict = None
         last_cond_dict = None
 
         if visual_fusion_config is None:
-            visual_fusion_config = {"visual_fusion_method": "spatial-checkerboard", "visual_block_size": 2, "dither_ratio": 0.5}
+            visual_fusion_config = {"visual_fusion_method": "spatial-checkerboard", "visual_block_size": 2, "dither_ratio": 0.5, "seed": 0}
         visual_method = visual_fusion_config.get("visual_fusion_method", "spatial-checkerboard")
 
         def process_vlm_image(image, res):
@@ -2243,20 +2213,19 @@ class TextEncodeEditScaledAdv(io.ComfyNode):
             if P_X is not None:
                 pooled_tensors[letter] = P_X
 
-            # Tokenize and find visual token range for isolation blending
-            try:
-                tokens = clip.tokenize(modified_prompt, images=[processed_img], skip_template=True)
-                tokens_dict[letter] = tokens
-                vis_start, vis_end = find_visual_token_range(tokens, C_X)
-                visual_ranges[letter] = (vis_start, vis_end)
-            except Exception:
-                visual_ranges[letter] = (0, 0)
+            if visual_method != "off":
+                try:
+                    tokens = clip.tokenize(modified_prompt, images=[processed_img], skip_template=True)
+                    tokens_dict[letter] = tokens
+                    vis_start, vis_end = find_visual_token_range(tokens, C_X)
+                    visual_ranges[letter] = (vis_start, vis_end)
+                except Exception as e:
+                    raise ValueError(f"Could not locate the visual token range for image {idx + 1}: {e}") from e
 
-            if idx == 0:
-                ref_cond_dict = cond_X[0][1]
             last_cond_dict = cond_X[0][1]
 
         # Evaluate mathematical formula or consensus on sequence and pooled tensors
+        fusion_mask_cache = {}
         if visual_method != "off":
             device = comfy.model_management.get_torch_device()
 
@@ -2265,7 +2234,7 @@ class TextEncodeEditScaledAdv(io.ComfyNode):
                 key_name = next(iter(tokens.keys()))
 
             C_blended, P_blended = evaluate_conditioning_consensus_blend(
-                sequence_tensors, pooled_tensors, visual_fusion_config=visual_fusion_config, device=device, visual_ranges=visual_ranges, embedding_key=key_name, clip=clip, tokens_dict=tokens_dict
+                sequence_tensors, pooled_tensors, visual_fusion_config=visual_fusion_config, device=device, visual_ranges=visual_ranges, embedding_key=key_name, clip=clip, tokens_dict=tokens_dict, mask_cache=fusion_mask_cache
             )
         else:
             C_blended, P_blended = evaluate_conditioning_formula(formula, sequence_tensors, pooled_tensors, padding_method=padding_method)
@@ -2790,7 +2759,7 @@ class TextEncodeKrea2SysEditScaledAdvAttn(io.ComfyNode):
         clean_system_prompt = system_prompt
 
         if visual_fusion_config is None:
-            visual_fusion_config = {"visual_fusion_method": "spatial-checkerboard", "visual_block_size": 2, "dither_ratio": 0.5}
+            visual_fusion_config = {"visual_fusion_method": "spatial-checkerboard", "visual_block_size": 2, "dither_ratio": 0.5, "seed": 0}
         visual_method = visual_fusion_config.get("visual_fusion_method", "spatial-checkerboard")
 
         def process_vlm_image(image, res):
@@ -2944,7 +2913,6 @@ class TextEncodeKrea2SysEditScaledAdvAttn(io.ComfyNode):
             deepstack_dict = {}
             visual_ranges = {}
             tokens_dict = {}
-            ref_cond_dict = None
             last_cond_dict = None
 
             for idx, img in enumerate(active_images):
@@ -2978,24 +2946,23 @@ class TextEncodeKrea2SysEditScaledAdvAttn(io.ComfyNode):
                 if P_X is not None:
                     pooled_tensors[letter] = P_X
 
-                # Tokenize and find visual token range for isolation blending
-                try:
-                    tokens = clip.tokenize(full_prompt, images=[processed_img], skip_template=True)
-                    tokens_dict[letter] = tokens
-                    vis_start, vis_end = find_visual_token_range(tokens, C_X)
-                    visual_ranges[letter] = (vis_start, vis_end)
-                except Exception:
-                    visual_ranges[letter] = (0, 0)
+                if visual_method != "off":
+                    try:
+                        tokens = clip.tokenize(full_prompt, images=[processed_img], skip_template=True)
+                        tokens_dict[letter] = tokens
+                        vis_start, vis_end = find_visual_token_range(tokens, C_X)
+                        visual_ranges[letter] = (vis_start, vis_end)
+                    except Exception as e:
+                        raise ValueError(f"Could not locate the visual token range for image {idx + 1}: {e}") from e
 
                 if "embeds_info" in cond_X[0][1] and len(cond_X[0][1]["embeds_info"]) > 0:
                     extra = cond_X[0][1]["embeds_info"][0].get("extra", {})
                     if "deepstack" in extra:
                         deepstack_dict[letter] = extra["deepstack"]
 
-                if idx == 0:
-                    ref_cond_dict = cond_X[0][1]
                 last_cond_dict = cond_X[0][1]
 
+            fusion_mask_cache = {}
             if visual_method != "off":
                 device = comfy.model_management.get_torch_device()
 
@@ -3004,64 +2971,38 @@ class TextEncodeKrea2SysEditScaledAdvAttn(io.ComfyNode):
                     key_name = next(iter(tokens.keys()))
 
                 C_blended, P_blended = evaluate_conditioning_consensus_blend(
-                    sequence_tensors, pooled_tensors, visual_fusion_config=visual_fusion_config, device=device, visual_ranges=visual_ranges, embedding_key=key_name, clip=clip, tokens_dict=tokens_dict
+                    sequence_tensors, pooled_tensors, visual_fusion_config=visual_fusion_config, device=device, visual_ranges=visual_ranges, embedding_key=key_name, clip=clip, tokens_dict=tokens_dict, mask_cache=fusion_mask_cache
                 )
             else:
                 C_blended, P_blended = evaluate_conditioning_formula(formula, sequence_tensors, pooled_tensors, padding_method=padding_method)
 
             deepstack_blended = None
             if deepstack_dict:
-                first_key = next(iter(sequence_tensors.keys()))
-                num_layers = len(deepstack_dict[first_key])
-                max_vis_len = max(ds_list[0].shape[0] for ds_list in deepstack_dict.values())
-
-                deepstack_blended = []
-
-
-                for l in range(num_layers):
-                    layer_tensors = {let: ds_list[l] for let, ds_list in deepstack_dict.items()}
-
-                    if visual_method != "off":
-                        wrapped_layer_tensors = {let: t.unsqueeze(0) for let, t in layer_tensors.items()}
-                        device = comfy.model_management.get_torch_device()
-                        # DeepStack intermediate layers are blended linearly for spatial stability
-                        C_l_blended, _ = evaluate_conditioning_consensus_blend(
-                            wrapped_layer_tensors, {}, visual_fusion_config={"visual_fusion_method": "linear"}, device=device
-                        )
-                        deepstack_blended.append(C_l_blended.squeeze(0))
-                    else:
+                if visual_method != "off":
+                    expected_visual_length = max(end - start for start, end in visual_ranges.values())
+                    deepstack_blended = fuse_deepstack_layers(deepstack_dict, visual_fusion_config, device, fusion_mask_cache, expected_visual_length)
+                else:
+                    first_key = next(iter(sequence_tensors.keys()))
+                    num_layers = len(deepstack_dict[first_key])
+                    max_vis_len = max(ds_list[0].shape[0] for ds_list in deepstack_dict.values())
+                    deepstack_blended = []
+                    for l in range(num_layers):
+                        layer_tensors = {let: ds_list[l] for let, ds_list in deepstack_dict.items()}
                         aligned_layer_tensors = {}
                         for name, tensor in layer_tensors.items():
                             if tensor.shape[0] < max_vis_len:
                                 if padding_method == "interpolate":
                                     tensor_perm = tensor.permute(1, 0).unsqueeze(0)
-                                    tensor_interp = F.interpolate(tensor_perm, size=max_vis_len, mode='linear', align_corners=False)
-                                    tensor = tensor_interp.squeeze(0).permute(1, 0)
+                                    tensor = F.interpolate(tensor_perm, size=max_vis_len, mode="linear", align_corners=False).squeeze(0).permute(1, 0)
                                 else:
-                                    pad_size = max_vis_len - tensor.shape[0]
-                                    padding = torch.zeros((pad_size, tensor.shape[1]), device=tensor.device, dtype=tensor.dtype)
+                                    padding = torch.zeros((max_vis_len - tensor.shape[0], tensor.shape[1]), device=tensor.device, dtype=tensor.dtype)
                                     tensor = torch.cat([tensor, padding], dim=0)
                             aligned_layer_tensors[name] = tensor
 
-                        safe_dict_layer = {
-                            "__builtins__": {},
-                            "clamp": torch.clamp,
-                            "min": torch.minimum,
-                            "max": torch.maximum,
-                            "abs": torch.abs,
-                        }
-                        for name, t in aligned_layer_tensors.items():
-                            safe_dict_layer[name] = t
-
-                        layer_expression = re.sub(
-                            r"\(\s*([a-zA-Z0-9_]+)\s*:\s*([0-9.-]+)\s*\)",
-                            r"(\1 * \2)",
-                            formula
-                        )
-
+                        safe_dict_layer = {"__builtins__": {}, "clamp": torch.clamp, "min": torch.minimum, "max": torch.maximum, "abs": torch.abs, **aligned_layer_tensors}
+                        layer_expression = re.sub(r"\(\s*([a-zA-Z0-9_]+)\s*:\s*([0-9.-]+)\s*\)", r"(\1 * \2)", formula)
                         try:
-                            layer_blended = eval(layer_expression, safe_dict_layer, {})
-                            deepstack_blended.append(layer_blended)
+                            deepstack_blended.append(eval(layer_expression, safe_dict_layer, {}))  # noqa: S307
                         except Exception as e:
                             raise RuntimeError(f"Error evaluating DeepStack math expression at layer {l}: {e}")
 

--- a/tests/test_visual_fusion.py
+++ b/tests/test_visual_fusion.py
@@ -1,0 +1,168 @@
+import pathlib
+import sys
+import types
+
+import pytest
+import torch
+
+
+CUSTOM_NODE_ROOT = pathlib.Path(__file__).parents[1]
+PACKAGE_NAME = "utils_collection_test"
+package = types.ModuleType(PACKAGE_NAME)
+package.__path__ = [str(CUSTOM_NODE_ROOT)]
+sys.modules.setdefault(PACKAGE_NAME, package)
+
+from comfy.cli_args import args as cli_args
+
+prior_cpu = cli_args.cpu
+cli_args.cpu = True
+try:
+    from utils_collection_test import encoder_helpers
+    from utils_collection_test.encoder_nodes import UC_VisualFusionConfig
+finally:
+    cli_args.cpu = prior_cpu
+
+
+def _config(method="spatial-dither-random", ratio=0.5, seed=0):
+    return {
+        "visual_fusion_method": method,
+        "visual_block_size": 2,
+        "dither_ratio": ratio,
+        "seed": seed,
+    }
+
+
+def test_dither_seed_and_secondary_checkerboard():
+    first = encoder_helpers.generate_spatial_fusion_mask(256, 3, "spatial-dither-random", dither_ratio=0.5, seed=7)
+    repeated = encoder_helpers.generate_spatial_fusion_mask(256, 3, "spatial-dither-random", dither_ratio=0.5, seed=7)
+    changed = encoder_helpers.generate_spatial_fusion_mask(256, 3, "spatial-dither-random", dither_ratio=0.5, seed=8)
+
+    assert torch.equal(first, repeated)
+    assert not torch.equal(first, changed)
+    assert encoder_helpers.generate_spatial_fusion_mask(6, 3, "spatial-dither-random", dither_ratio=0.0).tolist() == [1, 2, 2, 1, 1, 2]
+    assert encoder_helpers.generate_spatial_fusion_mask(6, 3, "spatial-dither-random", dither_ratio=1.0).tolist() == [0] * 6
+
+
+def test_old_mask_device_position_remains_compatible():
+    mask = encoder_helpers.generate_spatial_fusion_mask(4, 2, "spatial-checkerboard", 2, 0.5, "cpu")
+    assert mask.device.type == "cpu"
+    assert mask.tolist() == [0, 1, 1, 0]
+
+
+def test_spatial_fusion_matches_mask_and_preserves_dtype():
+    sources = [
+        torch.arange(12, dtype=torch.float16).reshape(6, 2),
+        torch.arange(100, 112, dtype=torch.float16).reshape(6, 2),
+        torch.arange(200, 212, dtype=torch.float16).reshape(6, 2),
+    ]
+    config = _config(seed=11)
+    mask = encoder_helpers.generate_spatial_fusion_mask(6, 3, "spatial-dither-random", dither_ratio=0.5, seed=11)
+    expected = torch.stack([sources[int(mask[index])][index] for index in range(6)])
+
+    output = encoder_helpers.fuse_visual_token_sources(sources, config, "cpu")
+
+    assert output.dtype == torch.float16
+    assert torch.equal(output, expected)
+
+
+def test_interpolation_only_aligns_unequal_lengths():
+    short = torch.tensor([[0.0], [2.0]], dtype=torch.float16)
+    long = torch.tensor([[10.0], [11.0], [12.0], [13.0]], dtype=torch.float16)
+
+    output = encoder_helpers.fuse_visual_token_sources([short, long], _config(ratio=1.0), "cpu")
+
+    assert output.shape == (4, 1)
+    assert output.dtype == torch.float16
+    assert output.flatten().tolist() == [0.0, 0.5, 1.5, 2.0]
+
+
+def test_deepstack_reuses_main_spatial_mask():
+    config = _config(seed=23)
+    cache = {}
+    main_sources = [torch.zeros(16, 1), torch.ones(16, 1)]
+    main = encoder_helpers.fuse_visual_token_sources(main_sources, config, "cpu", cache, 16)
+    deepstack = {
+        "a": [torch.full((16, 1), 10.0), torch.full((16, 1), 100.0)],
+        "b": [torch.full((16, 1), 20.0), torch.full((16, 1), 200.0)],
+    }
+
+    layers = encoder_helpers.fuse_deepstack_layers(deepstack, config, "cpu", cache, 16)
+
+    assert len(cache) == 1
+    assert torch.equal(main.bool(), layers[0].eq(20.0))
+    assert torch.equal(main.bool(), layers[1].eq(200.0))
+
+
+def test_saved_raw_embedding_uses_active_conditioning_mask(monkeypatch):
+    config = {**_config(seed=31), "save_blended_embeds": True}
+    cache = {}
+    sequence_tensors = {
+        "a": torch.zeros(1, 6, 1),
+        "b": torch.ones(1, 6, 1),
+    }
+    visual_ranges = {"a": (1, 5), "b": (1, 5)}
+    tokens = {
+        "a": {"qwen3vl_4b": [[(0, 1.0)]]},
+        "b": {"qwen3vl_4b": [[(1, 1.0)]]},
+    }
+
+    class ClipModel:
+        def process_tokens(self, tokens_only, device):
+            value = float(tokens_only[0][0])
+            return torch.full((1, 6, 2), value, device=device), None, None, None
+
+    class Clip:
+        cond_stage_model = ClipModel()
+
+    saved = []
+    monkeypatch.setattr(encoder_helpers, "save_blended_visual_embeddings", lambda tensors, config, key: saved.append(tensors[0]))
+
+    conditioning, _ = encoder_helpers.evaluate_conditioning_consensus_blend(
+        sequence_tensors,
+        {},
+        config,
+        "cpu",
+        visual_ranges,
+        clip=Clip(),
+        tokens_dict=tokens,
+        mask_cache=cache,
+    )
+
+    assert len(cache) == 1
+    assert torch.equal(conditioning[0, 1:5, 0], saved[0][:, 0])
+
+
+@pytest.mark.parametrize("method", ["index-consensus", "similarity-consensus", "unknown"])
+def test_unsupported_methods_raise(method):
+    with pytest.raises(ValueError, match="Unsupported visual fusion method"):
+        encoder_helpers.fuse_visual_token_sources([torch.zeros(4, 1), torch.ones(4, 1)], _config(method), "cpu")
+
+
+def test_config_seed_and_legacy_call_compatibility():
+    schema_inputs = UC_VisualFusionConfig.define_schema().inputs
+    inputs = {value.id: value for value in schema_inputs}
+    legacy = UC_VisualFusionConfig.execute("spatial-dither-random", 2, 0.5, False, "legacy.safetensors").args[0]
+    seeded = UC_VisualFusionConfig.execute("spatial-dither-random", 2, 0.5, seed=123).args[0]
+
+    assert [value.id for value in schema_inputs] == ["visual_fusion_method", "visual_block_size", "dither_ratio", "save_blended_embeds", "save_path", "seed"]
+    assert inputs["seed"].control_after_generate is True
+    assert "index-consensus" not in inputs["visual_fusion_method"].options
+    assert "similarity-consensus" not in inputs["visual_fusion_method"].options
+    assert legacy["seed"] == 0
+    assert legacy["save_path"] == "legacy.safetensors"
+    assert seeded["seed"] == 123
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+def test_cached_cuda_mask_matches_cpu_raw_fusion():
+    config = _config(seed=47)
+    cache = {}
+    gpu = encoder_helpers.fuse_visual_token_sources(
+        [torch.zeros(64, 1, device="cuda"), torch.ones(64, 1, device="cuda")],
+        config,
+        "cuda",
+        cache,
+    )
+    cpu = encoder_helpers.fuse_visual_token_sources([torch.zeros(64, 1), torch.ones(64, 1)], config, "cuda", cache)
+
+    assert torch.equal(gpu.cpu(), cpu)


### PR DESCRIPTION
Added configurable 64-bit dither seed with standard after-generation control.
Multi-source dither now applies the ratio to source 0 versus a checkerboard of remaining sources.
Vectorized token selection while preserving dtype.
Reused one execution-scoped mask for conditioning, raw saved embeddings, and DeepStack.
Applied the selected spatial method to DeepStack.
Removed unsupported consensus choices and added explicit errors.
Preserved existing unequal-length 1D interpolation behavior.
Kept existing widget positions compatible by appending seed last.