### PR TITLE
perf(composite): optimize staged face runtime

### DIFF
--- a/composite_nodes.py
+++ b/composite_nodes.py
@@ -13,8 +13,12 @@ from nodes import MAX_RESOLUTION
 from .helper_functions import resize_nchw
 from .model_assets import ensure_huggingface_model
 from .staged_face_helpers import (
-    detect_or_warn,
+    detect_many_or_warn,
     load_face_model,
+)
+from .staged_compositor_helpers import (
+    RetainedStageCache,
+    cached_layer_preview,
     projective_warp,
 )
 
@@ -925,11 +929,13 @@ def _stage_layered_foregrounds(
     gap_fill_radius,
     mask_resize_method="auto",
     placement_data=None,
+    retain_full_alpha=False,
 ):
     foregrounds = _ordered_single_foregrounds(foreground_images)
     if not foregrounds:
         raise ValueError("Layered foreground staging requires at least one foreground image.")
     layers = []
+    full_alpha_by_socket = {}
     placements = _parse_layer_placements(placement_data)
     for key, foreground in foregrounds:
         if foreground.shape[-1] < 3:
@@ -941,6 +947,7 @@ def _stage_layered_foregrounds(
             # A supplied alpha channel is an explicit foreground matte. Preserve
             # it exactly instead of replacing it with a removal-model estimate.
             refined = embedded_alpha[0].to(device=foreground.device, dtype=foreground.dtype).clamp(0.0, 1.0)
+            full_alpha = refined
         else:
             raw_mask = background_removal_model.encode_image(foreground)
             if not torch.is_tensor(raw_mask):
@@ -953,6 +960,7 @@ def _stage_layered_foregrounds(
                 raise ValueError(f"Background removal must return one [batch, height, width] mask for {key}.")
             if raw_mask.shape[-2:] != foreground.shape[1:3]:
                 raw_mask = _resize_composite_mask(raw_mask, foreground.shape[2], foreground.shape[1], mask_resize_method)
+            full_alpha = raw_mask[0].to(device=foreground.device, dtype=foreground.dtype).clamp(0.0, 1.0)
             refined = _refine_foreground_mask(
                 raw_mask[0],
                 float(mask_threshold),
@@ -960,6 +968,8 @@ def _stage_layered_foregrounds(
                 artifact_cleanup_radius,
                 gap_fill_radius,
             )
+        if retain_full_alpha:
+            full_alpha_by_socket[key] = full_alpha
         points = torch.nonzero(refined > 0, as_tuple=False)
         if points.numel() == 0:
             raise ValueError(f"Background removal produced an empty foreground mask for {key}.")
@@ -985,7 +995,8 @@ def _stage_layered_foregrounds(
             "flip_vertical": flip_vertical,
             "uses_embedded_alpha": uses_embedded_alpha,
         })
-    return {"version": 1, "layers": layers}
+    staged = {"version": 1, "layers": layers}
+    return (staged, full_alpha_by_socket) if retain_full_alpha else staged
 
 
 def _stage_face_foregrounds(
@@ -996,48 +1007,47 @@ def _stage_face_foregrounds(
     face_options,
     placement_data=None,
 ):
-    staged = _stage_layered_foregrounds(
+    staged, full_alpha_by_socket = _stage_layered_foregrounds(
         background_removal_model, foreground_images,
         background_options["mask_threshold"], background_options["border_cleanup_width"],
         background_options["artifact_cleanup_radius"], background_options["gap_fill_radius"],
-        background_options["mask_resize_method"], placement_data,
+        background_options["mask_resize_method"], placement_data, retain_full_alpha=True,
     )
     ordinary = {layer["socket"]: layer for layer in staged["layers"]}
     result, warning_count = [], 0
     ring = _ordered_ring(face_detection_model.connection_sets["face_oval"])
-    for key, original in _ordered_single_foregrounds(foreground_images):
+    foregrounds = _ordered_single_foregrounds(foreground_images)
+    detection_inputs = []
+    for key, original in foregrounds:
+        rgb = original[..., :3]
+        detection_inputs.append((
+            key,
+            rgb.mul(255).add(0.5).clamp(0, 255).to(torch.uint8).cpu().numpy()[0],
+        ))
+    detected_by_socket, failed_sockets = detect_many_or_warn(
+        face_detection_model,
+        detection_inputs,
+        face_options["maximum_faces"],
+        face_options["detection_threshold"],
+    )
+    warning_count = len(failed_sockets)
+
+    for key, original in foregrounds:
         result.append(ordinary[key])
         rgb = original[..., :3]
-        embedded_alpha = original[..., 3] if original.shape[-1] >= 4 else None
-        if embedded_alpha is None:
-            full_alpha = background_removal_model.encode_image(rgb)
-            if full_alpha.ndim == 4:
-                full_alpha = full_alpha[:, 0] if full_alpha.shape[1] == 1 else full_alpha[..., 0]
-            if full_alpha.shape[-2:] != rgb.shape[1:3]:
-                full_alpha = _resize_composite_mask(
-                    full_alpha, rgb.shape[2], rgb.shape[1], background_options["mask_resize_method"]
-                )
-            full_alpha = full_alpha[0].to(rgb)
-        else:
-            full_alpha = embedded_alpha[0].to(rgb)
-        image_uint8 = rgb.mul(255).add(0.5).clamp(0, 255).to(torch.uint8).cpu().numpy()[0]
-        faces, failed = detect_or_warn(
-            face_detection_model, image_uint8, face_options["maximum_faces"],
-            face_options["detection_threshold"], key,
-        )
-        if failed:
-            warning_count += 1
+        if key in failed_sockets:
             continue
+        full_alpha = full_alpha_by_socket[key]
+        faces = detected_by_socket[key]
         for face_index, face in enumerate(faces):
-            points = face["landmarks_xy"][ring]
-            face_mask = _polygon_mask(
-                rgb.shape[1], rgb.shape[2], points, rgb.device, rgb.dtype
-            )
-            face_mask = face_mask * full_alpha.clamp(0, 1)
             x1, y1, x2, y2 = _expanded_box(
                 face["bbox_xyxy"], face_options["bbox_expansion"], rgb.shape[2], rgb.shape[1]
             )
-            crop_mask = face_mask[y1:y2, x1:x2]
+            points = face["landmarks_xy"][ring] - np.asarray([x1, y1], dtype=np.float32)
+            crop_mask = _polygon_mask(
+                y2 - y1, x2 - x1, points, rgb.device, rgb.dtype
+            )
+            crop_mask = crop_mask * full_alpha[y1:y2, x1:x2].to(crop_mask)
             crop_mask = _expand_mask(crop_mask, face_options["mask_expansion"]).clamp(0, 1)[None]
             if not torch.any(crop_mask > 0):
                 continue
@@ -1094,10 +1104,10 @@ def _preview_staged_foregrounds(background, staged_foregrounds, feather_radius):
         editor_metadata["background_removal_model_name"] = staged_foregrounds["background_removal_model_name"]
     for layer in layers:
         crop = layer["image"]
-        alpha = layer["mask"][0]
         layer_feather = int(layer.get("feather_radius", feather_radius))
-        if layer_feather and (layer.get("is_face") or not layer.get("uses_embedded_alpha", False)):
-            alpha = _feather_mask(alpha, -layer_feather)
+        applies_feather = bool(
+            layer_feather and (layer.get("is_face") or not layer.get("uses_embedded_alpha", False))
+        )
         entry = {
             "socket": layer["socket"],
             "crop_width": crop.shape[2],
@@ -1108,8 +1118,19 @@ def _preview_staged_foregrounds(background, staged_foregrounds, feather_radius):
             "blend_factor": float(layer.get("blend_factor", 1.0)),
         }
         try:
-            rgba = torch.cat((crop[0], alpha.unsqueeze(-1)), dim=-1).unsqueeze(0)
-            entry["preview"] = _save_editor_preview(rgba, f"UC_layered_{layer['socket']}")
+            def build_preview_tensor():
+                alpha = layer["mask"][0]
+                if applies_feather:
+                    alpha = _feather_mask(alpha, -layer_feather)
+                return torch.cat((crop[0], alpha.unsqueeze(-1)), dim=-1).unsqueeze(0)
+
+            entry["preview"] = cached_layer_preview(
+                staged_foregrounds,
+                layer["socket"],
+                ("rgba-v1", layer_feather if applies_feather else 0),
+                build_preview_tensor,
+                lambda image: _save_editor_preview(image, f"UC_layered_{layer['socket']}"),
+            )
         except Exception:
             logging.warning(
                 "Unable to create staged editor cutout preview for %s.",
@@ -1160,6 +1181,8 @@ def _composite_staged_foregrounds(
         key = layer["socket"]
         crop = layer["image"]
         crop_mask = layer["mask"]
+        preview_crop = crop
+        preview_mask = crop_mask
         crop_height, crop_width = crop.shape[1:3]
         placement = placements.get(
             key,
@@ -1226,16 +1249,18 @@ def _composite_staged_foregrounds(
             combined_mask[0, destination_top:destination_bottom, destination_left:destination_right] = (
                 mask_region + base_alpha * (1.0 - mask_region)
             )
-        preview_alpha = crop_mask[0]
-        if layer_feather and (layer.get("is_face") or not layer.get("uses_embedded_alpha", False)):
-            preview_alpha = _feather_mask(preview_alpha, -layer_feather)
         editor_layers.append({
             "socket": key,
             "crop_width": crop_width,
             "crop_height": crop_height,
-            "preview_tensor": torch.cat((crop[0], preview_alpha.unsqueeze(-1)), dim=-1).unsqueeze(0),
-            "flip_horizontal": desired_flip,
-            "flip_vertical": desired_flip_vertical,
+            "preview_crop": preview_crop,
+            "preview_mask": preview_mask,
+            "preview_feather": layer_feather,
+            "preview_applies_feather": bool(
+                layer_feather and (layer.get("is_face") or not layer.get("uses_embedded_alpha", False))
+            ),
+            "flip_horizontal": staged_flip,
+            "flip_vertical": staged_flip_vertical,
             "is_face": bool(layer.get("is_face", False)),
             "included": not excluded,
             "blend_factor": float(layer.get("blend_factor", 1.0)),
@@ -1259,8 +1284,22 @@ def _composite_staged_foregrounds(
             )
         }
         try:
-            entry["preview"] = _save_editor_preview(
-                layer["preview_tensor"], f"UC_layered_{layer['socket']}"
+            def build_preview_tensor():
+                alpha = layer["preview_mask"][0]
+                if layer["preview_applies_feather"]:
+                    alpha = _feather_mask(alpha, -layer["preview_feather"])
+                return torch.cat(
+                    (layer["preview_crop"][0], alpha.unsqueeze(-1)), dim=-1
+                ).unsqueeze(0)
+
+            entry["preview"] = cached_layer_preview(
+                staged_foregrounds,
+                layer["socket"],
+                ("rgba-v1", layer["preview_feather"] if layer["preview_applies_feather"] else 0),
+                build_preview_tensor,
+                lambda image: _save_editor_preview(
+                    image, f"UC_layered_{layer['socket']}"
+                ),
             )
         except Exception:
             logging.warning("Unable to create staged editor cutout preview for %s.", layer["socket"], exc_info=True)
@@ -1345,7 +1384,7 @@ class UC_StagedMediaPipeFaceOptions(io.ComfyNode):
 
 
 class UC_StagedMediaPipeFaceBackgroundComposite(io.ComfyNode):
-    _staged_by_node = {}
+    _staged_by_node = RetainedStageCache(max_entries=8)
 
     @classmethod
     def define_schema(cls):
@@ -1401,6 +1440,7 @@ class UC_StagedMediaPipeFaceBackgroundComposite(io.ComfyNode):
             )
             staged["background_removal_model_name"] = str(background_removal_model_name).lower()
             cls._staged_by_node[node_id] = staged
+            staged = cls._staged_by_node[node_id]
             if execution_mode == "run_staging":
                 preview_stage = _apply_staged_layer_options(
                     staged,

--- a/staged_compositor_helpers.py
+++ b/staged_compositor_helpers.py
@@ -1,0 +1,119 @@
+from collections import OrderedDict
+from collections.abc import MutableMapping
+
+import torch
+import torch.nn.functional as F
+
+
+_DEFAULT_CORNERS = ((-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0))
+
+
+def _stored_tensor(tensor):
+    import comfy.model_management
+
+    stored = tensor.detach().to(
+        device=comfy.model_management.intermediate_device(),
+        dtype=comfy.model_management.intermediate_dtype(),
+    ).contiguous()
+    if stored.untyped_storage().data_ptr() == tensor.untyped_storage().data_ptr():
+        stored = stored.clone()
+    return stored
+
+
+class RetainedStageCache(MutableMapping):
+    def __init__(self, max_entries=8):
+        self.max_entries = max(1, int(max_entries))
+        self._entries = OrderedDict()
+
+    def __getitem__(self, key):
+        value = self._entries.pop(key)
+        self._entries[key] = value
+        return value
+
+    def __setitem__(self, key, value):
+        layers = [
+            {
+                **layer,
+                "image": _stored_tensor(layer["image"]),
+                "mask": _stored_tensor(layer["mask"]),
+            }
+            for layer in value["layers"]
+        ]
+        stored = {**value, "layers": layers, "_preview_cache": {}}
+        self._entries.pop(key, None)
+        self._entries[key] = stored
+        while len(self._entries) > self.max_entries:
+            self._entries.popitem(last=False)
+
+    def __delitem__(self, key):
+        del self._entries[key]
+
+    def __iter__(self):
+        return iter(self._entries)
+
+    def __len__(self):
+        return len(self._entries)
+
+    def clear(self):
+        self._entries.clear()
+
+
+def cached_layer_preview(staged, socket, cache_key, build_tensor, save_preview):
+    cache = staged.setdefault("_preview_cache", {})
+    cached = cache.get(socket)
+    if cached is not None and cached["key"] == cache_key:
+        return cached["preview"]
+    preview = save_preview(build_tensor())
+    if preview is not None:
+        cache[socket] = {"key": cache_key, "preview": preview}
+    return preview
+
+
+def is_identity_projective_transform(corners, rotation):
+    if float(rotation) != 0.0 or len(corners) != 4:
+        return False
+    return all(
+        len(corner) == 2
+        and float(corner[0]) == expected[0]
+        and float(corner[1]) == expected[1]
+        for corner, expected in zip(corners, _DEFAULT_CORNERS)
+    )
+
+
+def projective_warp(image, mask, corners, rotation=0.0):
+    """Warp BHWC RGB and BHW alpha through one shared inverse homography."""
+    if is_identity_projective_transform(corners, rotation):
+        return image, mask
+
+    device, dtype = image.device, image.dtype
+    destination = torch.tensor(corners, device=device, dtype=dtype)
+    angle = torch.deg2rad(destination.new_tensor(float(rotation)))
+    matrix = torch.stack((
+        torch.stack((torch.cos(angle), -torch.sin(angle))),
+        torch.stack((torch.sin(angle), torch.cos(angle))),
+    ))
+    destination = destination @ matrix.T
+    source = destination.new_tensor(_DEFAULT_CORNERS)
+    rows, values = [], []
+    for (x, y), (u, v) in zip(source, destination):
+        zero, one = x.new_tensor(0), x.new_tensor(1)
+        rows.extend([
+            torch.stack((x, y, one, zero, zero, zero, -u * x, -u * y)),
+            torch.stack((zero, zero, zero, x, y, one, -v * x, -v * y)),
+        ])
+        values.extend((u, v))
+    solved = torch.linalg.solve(torch.stack(rows), torch.stack(values))
+    inverse = torch.linalg.inv(torch.cat((solved, solved.new_ones(1))).reshape(3, 3))
+    height, width = image.shape[1:3]
+    ys = torch.linspace(-1, 1, height, device=device, dtype=dtype)
+    xs = torch.linspace(-1, 1, width, device=device, dtype=dtype)
+    yy, xx = torch.meshgrid(ys, xs, indexing="ij")
+    homogeneous = torch.stack((xx, yy, torch.ones_like(xx)), dim=-1)
+    mapped = homogeneous @ inverse.T
+    grid = mapped[..., :2] / mapped[..., 2:].clamp(min=1e-8)
+    rgba = torch.cat((image.movedim(-1, 1), mask.unsqueeze(1)), dim=1)
+    warped = F.grid_sample(
+        rgba, grid.unsqueeze(0), mode="bilinear",
+        padding_mode="zeros", align_corners=True,
+    )
+    return warped[:, :3].movedim(1, -1), warped[:, 3]

--- a/staged_face_helpers.py
+++ b/staged_face_helpers.py
@@ -1,10 +1,8 @@
 import logging
-import math
 import os
 
 import numpy as np
 import torch
-import torch.nn.functional as F
 
 from .model_assets import ensure_huggingface_model
 
@@ -76,27 +74,14 @@ def _merge_cluster(cluster):
     return merged
 
 
-def _run_detection(model, image_uint8, maximum_faces, threshold):
+def _run_detection_batch(model, images_uint8, maximum_faces, threshold):
     return model.detect_batch(
-        [image_uint8], num_faces=max(1, int(maximum_faces)) * 3,
+        images_uint8, num_faces=max(1, int(maximum_faces)) * 3,
         score_thresh=threshold, variant="full",
-    )[0] or []
+    )
 
 
-def detect_faces_adaptive(model, image_uint8, maximum_faces, threshold):
-    threshold = min(max(float(threshold), 0.01), 1.0)
-    candidates = _run_detection(model, image_uint8, maximum_faces, threshold)
-    # Lower confidence only as a recovery path. Running every lower threshold
-    # unconditionally turns detector noise into dozens of placeable layers.
-    if not candidates:
-        candidates = _run_detection(
-            model, image_uint8, maximum_faces, max(0.05, round(threshold * 0.7, 4))
-        )
-    if not candidates:
-        candidates = _run_detection(
-            model, image_uint8, maximum_faces, max(0.05, round(threshold * 0.5, 4))
-        )
-
+def _merged_faces(candidates, maximum_faces):
     clusters = []
     for face in sorted(candidates, key=lambda item: float(item.get("score", 0.0)), reverse=True):
         matching = next((cluster for cluster in clusters if any(_same_face(face, other) for other in cluster)), None)
@@ -109,51 +94,62 @@ def detect_faces_adaptive(model, image_uint8, maximum_faces, threshold):
     return merged[:max(1, int(maximum_faces))]
 
 
+def detect_faces_adaptive(model, image_uint8, maximum_faces, threshold):
+    results, failed = detect_many_or_warn(
+        model, [("", image_uint8)], maximum_faces, threshold
+    )
+    if failed:
+        raise RuntimeError("MediaPipe face detection failed.")
+    return results[""]
+
+
+def detect_many_or_warn(model, images, maximum_faces, threshold):
+    threshold = min(max(float(threshold), 0.01), 1.0)
+    thresholds = []
+    for value in (threshold, max(0.05, round(threshold * 0.7, 4)), max(0.05, round(threshold * 0.5, 4))):
+        if value not in thresholds:
+            thresholds.append(value)
+
+    results = {socket: [] for socket, _ in images}
+    pending = list(images)
+    failed = set()
+    for pass_threshold in thresholds:
+        if not pending:
+            break
+        try:
+            batches = _run_detection_batch(
+                model, [image for _, image in pending], maximum_faces, pass_threshold
+            )
+            pass_results = list(zip(pending, batches))
+        except Exception:
+            pass_results = []
+            for item in pending:
+                try:
+                    batches = _run_detection_batch(
+                        model, [item[1]], maximum_faces, pass_threshold
+                    )
+                    pass_results.append((item, batches[0]))
+                except Exception:
+                    failed.add(item[0])
+                    logging.warning(
+                        "MediaPipe face detection failed for %s; retaining ordinary foreground only.",
+                        item[0], exc_info=True,
+                    )
+
+        next_pending = []
+        for (socket, image), candidates in pass_results:
+            if socket in failed:
+                continue
+            if candidates:
+                results[socket] = _merged_faces(candidates, maximum_faces)
+            else:
+                next_pending.append((socket, image))
+        pending = next_pending
+    return results, failed
+
+
 def detect_or_warn(model, image_uint8, maximum_faces, threshold, socket):
-    try:
-        return detect_faces_adaptive(model, image_uint8, maximum_faces, threshold), False
-    except Exception:
-        logging.warning(
-            "MediaPipe face detection failed for %s; retaining ordinary foreground only.",
-            socket, exc_info=True,
-        )
-        return [], True
-
-
-def projective_warp(image, mask, corners, rotation=0.0):
-    """Warp BHWC RGB and BHW alpha through the same inverse homography."""
-    device, dtype = image.device, image.dtype
-    destination = torch.tensor(corners, device=device, dtype=dtype)
-    angle = math.radians(float(rotation))
-    matrix = destination.new_tensor([
-        [math.cos(angle), -math.sin(angle)],
-        [math.sin(angle), math.cos(angle)],
-    ])
-    destination = destination @ matrix.T
-    source = destination.new_tensor([[-1, -1], [1, -1], [1, 1], [-1, 1]])
-    rows, values = [], []
-    for (x, y), (u, v) in zip(source, destination):
-        zero, one = x.new_tensor(0), x.new_tensor(1)
-        rows.extend([
-            torch.stack((x, y, one, zero, zero, zero, -u*x, -u*y)),
-            torch.stack((zero, zero, zero, x, y, one, -v*x, -v*y)),
-        ])
-        values.extend((u, v))
-    solved = torch.linalg.solve(torch.stack(rows), torch.stack(values))
-    inverse = torch.linalg.inv(torch.cat((solved, solved.new_ones(1))).reshape(3, 3))
-    height, width = image.shape[1:3]
-    ys = torch.linspace(-1, 1, height, device=device, dtype=dtype)
-    xs = torch.linspace(-1, 1, width, device=device, dtype=dtype)
-    yy, xx = torch.meshgrid(ys, xs, indexing="ij")
-    homogeneous = torch.stack((xx, yy, torch.ones_like(xx)), dim=-1)
-    mapped = homogeneous @ inverse.T
-    grid = mapped[..., :2] / mapped[..., 2:].clamp(min=1e-8)
-    warped_image = F.grid_sample(
-        image.movedim(-1, 1), grid.unsqueeze(0), mode="bilinear",
-        padding_mode="zeros", align_corners=True,
-    ).movedim(1, -1)
-    warped_mask = F.grid_sample(
-        mask.unsqueeze(1), grid.unsqueeze(0), mode="bilinear",
-        padding_mode="zeros", align_corners=True,
-    ).squeeze(1)
-    return warped_image, warped_mask
+    results, failed = detect_many_or_warn(
+        model, [(socket, image_uint8)], maximum_faces, threshold
+    )
+    return results[socket], socket in failed

--- a/tests/test_composite_nodes.py
+++ b/tests/test_composite_nodes.py
@@ -19,7 +19,12 @@ from comfy.cli_args import args as cli_args
 prior_cpu = cli_args.cpu
 cli_args.cpu = True
 try:
-    from utils_collection_composite_test import composite_nodes, image_nodes, model_assets
+    from utils_collection_composite_test import (
+        composite_nodes,
+        image_nodes,
+        model_assets,
+        staged_compositor_helpers,
+    )
     from utils_collection_composite_test.helper_functions import resize_nchw
 finally:
     cli_args.cpu = prior_cpu
@@ -648,7 +653,7 @@ def test_staged_layered_composite_tracks_and_applies_horizontal_flip(monkeypatch
         torch.zeros(1, 10, 10, 3), staged,
         '{"version":2,"layers":{"foreground_0":{"flip_horizontal":false}}}', 0,
     )
-    assert output.ui["uc_layered_scene_editor"][0]["layers"][0]["flip_horizontal"] is False
+    assert output.ui["uc_layered_scene_editor"][0]["layers"][0]["flip_horizontal"] is True
 
 
 def test_staged_layered_composite_tracks_and_applies_vertical_flip(monkeypatch):
@@ -669,7 +674,7 @@ def test_staged_layered_composite_tracks_and_applies_vertical_flip(monkeypatch):
         torch.zeros(1, 10, 10, 3), staged,
         '{"version":2,"layers":{"foreground_0":{"flip_vertical":false}}}', 0,
     )
-    assert output.ui["uc_layered_scene_editor"][0]["layers"][0]["flip_vertical"] is False
+    assert output.ui["uc_layered_scene_editor"][0]["layers"][0]["flip_vertical"] is True
 
 
 def test_staged_layered_composite_rejects_missing_stage():
@@ -1337,3 +1342,261 @@ def test_final_face_feather_scales_with_placed_face(monkeypatch):
         0,
     )
     assert radii[:2] == [-8, -4]
+
+
+def test_staged_face_reuses_first_raw_background_alpha():
+    class CountingBackground:
+        def __init__(self):
+            self.calls = 0
+
+        def encode_image(self, image):
+            self.calls += 1
+            return torch.full(image.shape[:3], 0.75, device=image.device, dtype=image.dtype)
+
+    background_model = CountingBackground()
+    staged = composite_nodes._stage_face_foregrounds(
+        background_model,
+        _FaceModel(),
+        {"foreground_0": torch.ones(1, 20, 20, 3)},
+        composite_nodes.UC_StagedLayeredBackgroundCompositeOptions.DEFAULTS,
+        composite_nodes.UC_StagedMediaPipeFaceOptions.DEFAULTS | {"bbox_expansion": 0},
+    )
+
+    assert background_model.calls == 1
+    assert torch.all(staged["layers"][0]["mask"] == 1)
+    assert staged["layers"][1]["mask"].max().item() == pytest.approx(0.75)
+
+
+def test_staged_face_detection_batches_foregrounds():
+    class BatchedFaceModel(_FaceModel):
+        def detect_batch(self, images, num_faces, score_thresh, variant):
+            self.calls.append((len(images), num_faces, score_thresh, variant))
+            results = []
+            for image in images:
+                height, width = image.shape[:2]
+                landmarks = np.array([
+                    [width * 0.25, height * 0.5],
+                    [width * 0.5, height * 0.25],
+                    [width * 0.75, height * 0.5],
+                    [width * 0.5, height * 0.75],
+                ], dtype=np.float32)
+                results.append([{
+                    "bbox_xyxy": np.array(
+                        [width * 0.25, height * 0.25, width * 0.75, height * 0.75],
+                        dtype=np.float32,
+                    ),
+                    "landmarks_xy": landmarks,
+                    "score": 0.9,
+                    "presence": 1.0,
+                }])
+            return results
+
+    model = BatchedFaceModel()
+    foregrounds = {
+        "foreground_0": torch.ones(1, 20, 20, 4),
+        "foreground_1": torch.ones(1, 24, 16, 4),
+    }
+    staged = composite_nodes._stage_face_foregrounds(
+        _BackgroundModel(),
+        model,
+        foregrounds,
+        composite_nodes.UC_StagedLayeredBackgroundCompositeOptions.DEFAULTS,
+        composite_nodes.UC_StagedMediaPipeFaceOptions.DEFAULTS | {"bbox_expansion": 0},
+    )
+
+    assert [call[0] for call in model.calls] == [2]
+    assert [layer["socket"] for layer in staged["layers"]] == [
+        "foreground_0", "foreground_0_face_0",
+        "foreground_1", "foreground_1_face_0",
+    ]
+
+
+def test_staged_face_detection_retries_only_batch_misses():
+    class RetryFaceModel(_FaceModel):
+        def detect_batch(self, images, num_faces, score_thresh, variant):
+            self.calls.append((len(images), score_thresh))
+            if len(self.calls) == 1:
+                return [[{
+                    "bbox_xyxy": np.array([4, 4, 12, 12], dtype=np.float32),
+                    "landmarks_xy": np.array([[4, 8], [8, 4], [12, 8], [8, 12]], dtype=np.float32),
+                    "score": 0.9,
+                    "presence": 1.0,
+                }], []]
+            return [[{
+                "bbox_xyxy": np.array([4, 4, 12, 12], dtype=np.float32),
+                "landmarks_xy": np.array([[4, 8], [8, 4], [12, 8], [8, 12]], dtype=np.float32),
+                "score": 0.6,
+                "presence": 1.0,
+            }]]
+
+    model = RetryFaceModel()
+    composite_nodes._stage_face_foregrounds(
+        _BackgroundModel(),
+        model,
+        {
+            "foreground_0": torch.ones(1, 20, 20, 4),
+            "foreground_1": torch.ones(1, 20, 20, 4),
+        },
+        composite_nodes.UC_StagedLayeredBackgroundCompositeOptions.DEFAULTS,
+        composite_nodes.UC_StagedMediaPipeFaceOptions.DEFAULTS | {"bbox_expansion": 0},
+    )
+
+    assert model.calls == [(2, 0.25), (1, 0.175)]
+
+
+def test_staged_face_rasterizes_crop_local_masks(monkeypatch):
+    sizes = []
+    original = composite_nodes._polygon_mask
+
+    def capture(height, width, points, device, dtype):
+        sizes.append((height, width))
+        return original(height, width, points, device, dtype)
+
+    monkeypatch.setattr(composite_nodes, "_polygon_mask", capture)
+    composite_nodes._stage_face_foregrounds(
+        _BackgroundModel(),
+        _FaceModel(),
+        {"foreground_0": torch.ones(1, 20, 20, 4)},
+        composite_nodes.UC_StagedLayeredBackgroundCompositeOptions.DEFAULTS,
+        composite_nodes.UC_StagedMediaPipeFaceOptions.DEFAULTS | {"bbox_expansion": 0},
+    )
+
+    assert sizes
+    assert all(height < 20 and width < 20 for height, width in sizes)
+
+
+def test_identity_projective_transform_skips_grid_sample(monkeypatch):
+    def fail(*args, **kwargs):
+        raise AssertionError("identity transform sampled a grid")
+
+    monkeypatch.setattr(staged_compositor_helpers.F, "grid_sample", fail)
+    image = torch.rand(1, 7, 9, 3)
+    mask = torch.rand(1, 7, 9)
+    warped_image, warped_mask = composite_nodes.projective_warp(
+        image, mask, [[-1, -1], [1, -1], [1, 1], [-1, 1]], 0,
+    )
+
+    assert warped_image is image
+    assert warped_mask is mask
+
+
+def test_projective_transform_samples_rgb_and_alpha_once(monkeypatch):
+    calls = []
+    original = staged_compositor_helpers.F.grid_sample
+
+    def capture(*args, **kwargs):
+        calls.append(args[0].shape)
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(staged_compositor_helpers.F, "grid_sample", capture)
+    composite_nodes.projective_warp(
+        torch.ones(1, 9, 9, 3),
+        torch.ones(1, 9, 9),
+        [[-0.8, -0.8], [0.8, -1], [0.7, 0.8], [-0.9, 0.7]],
+        12,
+    )
+
+    assert calls == [(1, 4, 9, 9)]
+
+
+def test_retained_stage_cache_copies_crops_and_evicts_lru():
+    source = torch.ones(1, 20, 20, 3)
+    source_mask = torch.ones(1, 20, 20)
+    cache = staged_compositor_helpers.RetainedStageCache(max_entries=8)
+
+    def stage(index):
+        return {
+            "version": 1,
+            "layers": [{
+                "socket": f"foreground_{index}",
+                "image": source[:, 2:8, 3:9],
+                "mask": source_mask[:, 2:8, 3:9],
+            }],
+        }
+
+    cache["stage-0"] = stage(0)
+    cache["stage-1"] = stage(1)
+    stored = cache["stage-0"]["layers"][0]
+    assert stored["image"].is_contiguous()
+    assert stored["mask"].is_contiguous()
+    assert stored["image"].untyped_storage().data_ptr() != source.untyped_storage().data_ptr()
+    assert stored["mask"].untyped_storage().data_ptr() != source_mask.untyped_storage().data_ptr()
+    assert stored["image"].untyped_storage().nbytes() == stored["image"].numel() * stored["image"].element_size()
+
+    for index in range(2, 9):
+        cache[f"stage-{index}"] = stage(index)
+    assert "stage-1" not in cache
+    assert list(cache) == ["stage-0", *(f"stage-{index}" for index in range(2, 9))]
+
+
+def test_staged_preview_reuses_files_until_feather_changes(monkeypatch):
+    saved = []
+
+    def save(image, prefix):
+        saved.append((image.clone(), prefix))
+        return {"filename": f"{prefix}-{len(saved)}.png"}
+
+    monkeypatch.setattr(composite_nodes, "_save_editor_preview", save)
+    staged = {
+        "version": 1,
+        "_preview_cache": {},
+        "layers": [{
+            "socket": "foreground_0_face_0",
+            "image": torch.ones(1, 9, 9, 3),
+            "mask": torch.ones(1, 9, 9),
+            "is_face": True,
+            "uses_embedded_alpha": True,
+            "feather_radius": 2,
+        }],
+    }
+    background = torch.zeros(1, 16, 16, 3)
+
+    first = composite_nodes._preview_staged_foregrounds(background, staged, 0)
+    second = composite_nodes._preview_staged_foregrounds(background, staged, 0)
+    changed = composite_nodes._preview_staged_foregrounds(
+        background,
+        {**staged, "layers": [{**staged["layers"][0], "feather_radius": 3}]},
+        0,
+    )
+
+    assert len(saved) == 2
+    assert first.ui["uc_layered_scene_editor"][0]["layers"][0]["preview"] == (
+        second.ui["uc_layered_scene_editor"][0]["layers"][0]["preview"]
+    )
+    assert changed.ui["uc_layered_scene_editor"][0]["layers"][0]["preview"] != (
+        first.ui["uc_layered_scene_editor"][0]["layers"][0]["preview"]
+    )
+
+
+def test_face_run_staged_loads_no_models(monkeypatch):
+    node = composite_nodes.UC_StagedMediaPipeFaceBackgroundComposite
+    node._staged_by_node.clear()
+    monkeypatch.setattr(node, "hidden", types.SimpleNamespace(unique_id="retained-face"))
+    monkeypatch.setattr(
+        composite_nodes,
+        "_load_internal_background_removal_model",
+        lambda *args: (_ for _ in ()).throw(AssertionError("loaded removal model")),
+    )
+    monkeypatch.setattr(
+        composite_nodes,
+        "load_face_model",
+        lambda *args: (_ for _ in ()).throw(AssertionError("loaded face model")),
+    )
+    monkeypatch.setattr(composite_nodes, "_save_editor_preview", lambda *args: None)
+    node._staged_by_node["retained-face"] = {
+        "version": 1,
+        "layers": [{
+            "socket": "foreground_0",
+            "image": torch.ones(1, 4, 4, 3),
+            "mask": torch.ones(1, 4, 4),
+            "uses_embedded_alpha": True,
+        }],
+    }
+
+    output = node.execute(
+        background=torch.zeros(1, 12, 12, 3),
+        foreground_images={"foreground_0": None},
+        execution_mode="run_staged",
+        placement_data='{"version":3,"layers":{}}',
+    )
+    assert output.result[0].sum() > 0


### PR DESCRIPTION
- Reuse each foreground removal mask during face extraction.
- Batch MediaPipe detection and retry only images without faces.
- Rasterize face masks within their expanded crop bounds.
- Skip identity projective transforms and warp RGB and alpha together.
- Store compact intermediate-device crop copies in a bounded LRU cache.
- Reuse staged preview files until pixel-affecting options change.
- Cover inference counts, allocation bounds, cache reuse, and transforms.