### PR TITLE
feat: add high-resolution tiled sampling

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -118,6 +118,7 @@ class SamplingUtils(ComfyExtension):
             UC_EncoderNodesGuide,
             UC_CompositeNodesGuide,
             UC_HighResolutionTilingGuide,
+            UC_MarkdownPreview,
             UC_LoraLoaderCLIPOnly,
             UC_LoadImageWithAlpha,
             UC_BoldFrakturTextStyle,

--- a/__init__.py
+++ b/__init__.py
@@ -83,6 +83,8 @@ class SamplingUtils(ComfyExtension):
             UC_TagNormalizeCombine,
             UC_LoadImagePath,
             UC_LoadImageDirectory,
+            UC_HighResolutionTileSplit,
+            UC_HighResolutionTileAccumulator,
             UC_ListToImageBatch,
             UC_SwitchInverseNode,
             UC_SoftSwitchInverseNode,

--- a/__init__.py
+++ b/__init__.py
@@ -117,6 +117,7 @@ class SamplingUtils(ComfyExtension):
             UC_Qwen3VLInputEmbeds,
             UC_EncoderNodesGuide,
             UC_CompositeNodesGuide,
+            UC_HighResolutionTilingGuide,
             UC_LoraLoaderCLIPOnly,
             UC_LoadImageWithAlpha,
             UC_BoldFrakturTextStyle,

--- a/image_nodes.py
+++ b/image_nodes.py
@@ -11,12 +11,16 @@ from tqdm import tqdm
 from PIL import Image, ImageOps, ImageSequence, ImageDraw, ImageFont
 import kornia.morphology as morph
 from .helper_functions import pil2tensor, math_diag, pct_to_px, composite, fill_mask_from_edges, iterative_directional_stretch_fill, gaussian_blur_nchw, hex_to_rgb, string_to_color, match_image_properties, resize_nchw, FLOW_PRESETS
+from .tile_helpers import accumulate_tile_images, split_and_encode_tiles
 
 
 from comfy_api.latest import io
 from comfy import model_management
 import node_helpers
 from nodes import MAX_RESOLUTION
+
+HighResolutionTileLayout = io.Custom("UC_HIGH_RES_TILE_LAYOUT")
+
 
 class UC_Image_Color_Noise(io.ComfyNode):
     @classmethod
@@ -1406,6 +1410,180 @@ class UC_ImagePad(io.ComfyNode):
                 out_masks[m, pad_top:pad_top+H, pad_left:pad_left+W] = 0.0
 
         return io.NodeOutput(out_image, out_masks)
+
+
+class UC_HighResolutionTileSplit(io.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="UC_HighResolutionTileSplit",
+            display_name="High Resolution Tile Split & VAE Encode",
+            category="image/tiling",
+            description=(
+                "Splits one pre-upscaled image into overlapping tiles, then "
+                "VAE-encodes every tile sequentially for list-mapped sampling."
+            ),
+            inputs=[
+                io.Image.Input("image"),
+                io.Vae.Input("vae"),
+                io.Combo.Input(
+                    "tile_mode",
+                    options=["tile_size", "grid"],
+                    default="tile_size",
+                    tooltip=(
+                        "tile_size uses tile width and height. grid uses rows "
+                        "and columns. Controls for the other mode are ignored."
+                    ),
+                ),
+                io.Int.Input(
+                    "tile_width",
+                    default=1024,
+                    min=64,
+                    max=MAX_RESOLUTION,
+                    step=8,
+                    tooltip="Processed tile width in tile_size mode.",
+                ),
+                io.Int.Input(
+                    "tile_height",
+                    default=1024,
+                    min=64,
+                    max=MAX_RESOLUTION,
+                    step=8,
+                    tooltip="Processed tile height in tile_size mode.",
+                ),
+                io.Int.Input(
+                    "rows",
+                    default=2,
+                    min=1,
+                    max=256,
+                    step=1,
+                    tooltip="Number of tile rows in grid mode.",
+                ),
+                io.Int.Input(
+                    "columns",
+                    default=2,
+                    min=1,
+                    max=256,
+                    step=1,
+                    tooltip="Number of tile columns in grid mode.",
+                ),
+                io.Int.Input(
+                    "overlap",
+                    default=128,
+                    min=0,
+                    max=MAX_RESOLUTION // 2,
+                    step=8,
+                    tooltip=(
+                        "Actual shared pixels between neighboring tiles in "
+                        "both tiling modes."
+                    ),
+                ),
+                io.Combo.Input(
+                    "mask_profile",
+                    options=["cosine", "linear"],
+                    default="cosine",
+                    tooltip="Transition profile used for overlap denoising and reconstruction.",
+                ),
+                io.Float.Input(
+                    "feather_width",
+                    default=1.0,
+                    min=0.0,
+                    max=1.0,
+                    step=0.01,
+                    tooltip="Fraction of each overlap occupied by the mask transition.",
+                ),
+                io.Float.Input(
+                    "mask_strength",
+                    default=1.0,
+                    min=0.0,
+                    max=1.0,
+                    step=0.01,
+                    tooltip=(
+                        "Overlap edge protection. 0 leaves the mask flat; "
+                        "1 reaches zero at protected internal tile edges."
+                    ),
+                ),
+            ],
+            outputs=[
+                io.Image.Output(
+                    "tile_images",
+                    display_name="tile images",
+                    is_output_list=True,
+                    tooltip="Individual image tiles for list-mapped visual conditioning.",
+                ),
+                io.Latent.Output(
+                    "tile_latents",
+                    display_name="tile latents",
+                    is_output_list=True,
+                    tooltip="Matching VAE latents with Core-compatible noise masks.",
+                ),
+                HighResolutionTileLayout.Output(
+                    "tile_layout",
+                    display_name="tile layout",
+                    tooltip="Coordinate and overlap metadata for the tile accumulator.",
+                ),
+            ],
+        )
+
+    @classmethod
+    def execute(
+        cls,
+        image,
+        vae,
+        tile_mode,
+        tile_width,
+        tile_height,
+        rows,
+        columns,
+        overlap,
+        mask_profile,
+        feather_width,
+        mask_strength,
+    ) -> io.NodeOutput:
+        image_tiles, latent_tiles, layout = split_and_encode_tiles(
+            image,
+            vae,
+            tile_mode,
+            tile_width,
+            tile_height,
+            rows,
+            columns,
+            overlap,
+            mask_profile,
+            feather_width,
+            mask_strength,
+        )
+        return io.NodeOutput(image_tiles, latent_tiles, layout)
+
+
+class UC_HighResolutionTileAccumulator(io.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="UC_HighResolutionTileAccumulator",
+            display_name="High Resolution Tile Accumulator",
+            category="image/tiling",
+            description=(
+                "Collects a completed decoded tile list and reconstructs the "
+                "original canvas with normalized overlap blending."
+            ),
+            is_input_list=True,
+            inputs=[
+                io.Image.Input(
+                    "images",
+                    tooltip="Decoded image list produced by the mapped sampler path.",
+                ),
+                HighResolutionTileLayout.Input(
+                    "tile_layout",
+                    tooltip="Layout from High Resolution Tile Split & VAE Encode.",
+                ),
+            ],
+            outputs=[io.Image.Output("image", display_name="image")],
+        )
+
+    @classmethod
+    def execute(cls, images, tile_layout) -> io.NodeOutput:
+        return io.NodeOutput(accumulate_tile_images(images, tile_layout))
 
 
 class UC_ListToImageBatch(io.ComfyNode):

--- a/image_nodes.py
+++ b/image_nodes.py
@@ -11,7 +11,11 @@ from tqdm import tqdm
 from PIL import Image, ImageOps, ImageSequence, ImageDraw, ImageFont
 import kornia.morphology as morph
 from .helper_functions import pil2tensor, math_diag, pct_to_px, composite, fill_mask_from_edges, iterative_directional_stretch_fill, gaussian_blur_nchw, hex_to_rgb, string_to_color, match_image_properties, resize_nchw, FLOW_PRESETS
-from .tile_helpers import accumulate_tile_images, split_and_encode_tiles
+from .tile_helpers import (
+    accumulate_tile_images,
+    apply_tile_differential_diffusion,
+    split_and_encode_tiles,
+)
 
 
 from comfy_api.latest import io
@@ -1426,6 +1430,14 @@ class UC_HighResolutionTileSplit(io.ComfyNode):
             inputs=[
                 io.Image.Input("image"),
                 io.Vae.Input("vae"),
+                io.Model.Input(
+                    "model",
+                    optional=True,
+                    tooltip=(
+                        "Optional diffusion model. Required only when a "
+                        "Differential Diffusion mode is enabled."
+                    ),
+                ),
                 io.Combo.Input(
                     "tile_mode",
                     options=["tile_size", "grid"],
@@ -1503,6 +1515,29 @@ class UC_HighResolutionTileSplit(io.ComfyNode):
                         "1 reaches zero at protected internal tile edges."
                     ),
                 ),
+                io.Combo.Input(
+                    "differential_diffusion_mode",
+                    options=["off", "core", "advanced"],
+                    default="off",
+                    tooltip=(
+                        "off leaves the model unchanged. core applies "
+                        "ComfyUI Core Differential Diffusion. advanced uses "
+                        "the threshold multiplier control."
+                    ),
+                ),
+                io.Float.Input(
+                    "differential_diffusion_value",
+                    default=1.0,
+                    min=-10.0,
+                    max=10.0,
+                    step=0.001,
+                    tooltip=(
+                        "Mode-dependent value. Core: strength from 0 to 1, "
+                        "blending its progressive binary mask with the soft "
+                        "mask. Advanced: nonzero threshold divisor from -10 "
+                        "to 10, matching KJNodes Differential Diffusion Advanced."
+                    ),
+                ),
             ],
             outputs=[
                 io.Image.Output(
@@ -1522,6 +1557,14 @@ class UC_HighResolutionTileSplit(io.ComfyNode):
                     display_name="tile layout",
                     tooltip="Coordinate and overlap metadata for the tile accumulator.",
                 ),
+                io.Model.Output(
+                    "model",
+                    display_name="model",
+                    tooltip=(
+                        "Differential Diffusion model for the sampler guider, "
+                        "or the unchanged connected model when mode is off."
+                    ),
+                ),
             ],
         )
 
@@ -1539,6 +1582,9 @@ class UC_HighResolutionTileSplit(io.ComfyNode):
         mask_profile,
         feather_width,
         mask_strength,
+        model=None,
+        differential_diffusion_mode="off",
+        differential_diffusion_value=1.0,
     ) -> io.NodeOutput:
         image_tiles, latent_tiles, layout = split_and_encode_tiles(
             image,
@@ -1553,7 +1599,12 @@ class UC_HighResolutionTileSplit(io.ComfyNode):
             feather_width,
             mask_strength,
         )
-        return io.NodeOutput(image_tiles, latent_tiles, layout)
+        output_model = apply_tile_differential_diffusion(
+            model,
+            differential_diffusion_mode,
+            differential_diffusion_value,
+        )
+        return io.NodeOutput(image_tiles, latent_tiles, layout, output_model)
 
 
 class UC_HighResolutionTileAccumulator(io.ComfyNode):

--- a/tests/test_high_resolution_tiling.py
+++ b/tests/test_high_resolution_tiling.py
@@ -19,6 +19,7 @@ from utils_collection_high_resolution_tiling_test.image_nodes import (
 )
 from utils_collection_high_resolution_tiling_test.tile_helpers import (
     accumulate_tile_images,
+    apply_tile_differential_diffusion,
     build_tile_records,
     split_and_encode_tiles,
     tile_weight_mask,
@@ -47,6 +48,46 @@ class MockVAE:
         )
 
 
+class MockFiveDimensionalImageVAE(MockVAE):
+    def encode(self, image):
+        self.calls.append(tuple(image.shape))
+        return torch.zeros(
+            (
+                image.shape[0],
+                16,
+                1,
+                image.shape[1] // self.compression,
+                image.shape[2] // self.compression,
+            ),
+            dtype=image.dtype,
+            device=image.device,
+        )
+
+
+class MockModel:
+    def __init__(self):
+        self.denoise_mask_function = None
+
+    def clone(self):
+        return MockModel()
+
+    def set_model_denoise_mask_function(self, function):
+        self.denoise_mask_function = function
+
+
+class MockSampling:
+    sigma_min = 0.0
+
+    @staticmethod
+    def timestep(sigma):
+        return sigma
+
+
+class MockSamplingModel:
+    def __init__(self):
+        self.inner_model = types.SimpleNamespace(model_sampling=MockSampling())
+
+
 def _split(image, vae=None, **overrides):
     settings = {
         "tile_mode": "tile_size",
@@ -73,14 +114,21 @@ def test_public_schema_and_list_contract():
         "tile_images",
         "tile_latents",
         "tile_layout",
+        "model",
     ]
     assert [output.is_output_list for output in split_schema.outputs] == [
         True,
         True,
         False,
+        False,
     ]
     assert split_schema.outputs[2].io_type == "UC_HIGH_RES_TILE_LAYOUT"
     assert HighResolutionTileLayout.io_type == "UC_HIGH_RES_TILE_LAYOUT"
+    input_ids = [value.id for value in split_schema.inputs]
+    assert input_ids[-2:] == [
+        "differential_diffusion_mode",
+        "differential_diffusion_value",
+    ]
 
     assert accumulator_schema.node_id == "UC_HighResolutionTileAccumulator"
     assert accumulator_schema.display_name == "High Resolution Tile Accumulator"
@@ -231,6 +279,18 @@ def test_split_encodes_each_tile_sequentially_and_attaches_masks():
     assert torch.all(latents[2]["noise_mask"][:, :, 4:, :] == 0)
 
 
+def test_split_accepts_image_vae_with_singleton_temporal_latent_axis():
+    image = torch.rand(1, 8, 14, 3)
+    images, latents, layout = _split(
+        image,
+        MockFiveDimensionalImageVAE(compression=8),
+    )
+
+    assert len(images) == len(latents) == len(layout["tiles"]) == 2
+    assert all(latent["samples"].shape == (1, 16, 1, 1, 1) for latent in latents)
+    assert all(latent["noise_mask"].ndim == 4 for latent in latents)
+
+
 @pytest.mark.parametrize(
     ("shape", "settings"),
     [
@@ -336,3 +396,53 @@ def test_node_execute_returns_synchronized_outputs():
         [output[2]],
     ).args[0]
     assert torch.allclose(merged, image, atol=1e-6)
+    assert output[3] is None
+
+
+def test_tile_differential_diffusion_off_preserves_model_identity():
+    model = MockModel()
+
+    assert apply_tile_differential_diffusion(model, "off", 1.0) is model
+
+
+def test_tile_differential_diffusion_core_uses_core_mask_behavior():
+    model = apply_tile_differential_diffusion(MockModel(), "core", 0.5)
+    mask = torch.tensor([[[[0.2, 0.6]]]])
+    result = model.denoise_mask_function(
+        torch.tensor([0.5]),
+        mask,
+        {
+            "model": MockSamplingModel(),
+            "sigmas": torch.tensor([1.0, 0.0]),
+        },
+    )
+
+    assert torch.allclose(result, torch.tensor([[[[0.1, 0.8]]]]))
+
+
+def test_tile_differential_diffusion_advanced_uses_threshold_multiplier():
+    model = apply_tile_differential_diffusion(
+        MockModel(),
+        "advanced",
+        2.0,
+    )
+    mask = torch.tensor([[[[0.2, 0.3]]]])
+    result = model.denoise_mask_function(
+        torch.tensor([0.5]),
+        mask,
+        {
+            "model": MockSamplingModel(),
+            "sigmas": torch.tensor([1.0, 0.0]),
+        },
+    )
+
+    assert torch.equal(result, torch.tensor([[[[0.0, 1.0]]]]))
+
+
+def test_tile_differential_diffusion_validation_is_actionable():
+    with pytest.raises(ValueError, match="Connect a model"):
+        apply_tile_differential_diffusion(None, "core", 1.0)
+    with pytest.raises(ValueError, match="between 0.0 and 1.0"):
+        apply_tile_differential_diffusion(MockModel(), "core", 2.0)
+    with pytest.raises(ValueError, match="cannot be zero"):
+        apply_tile_differential_diffusion(MockModel(), "advanced", 0.0)

--- a/tests/test_high_resolution_tiling.py
+++ b/tests/test_high_resolution_tiling.py
@@ -1,0 +1,338 @@
+import pathlib
+import sys
+import types
+
+import pytest
+import torch
+
+
+CUSTOM_NODE_ROOT = pathlib.Path(__file__).parents[1]
+PACKAGE_NAME = "utils_collection_high_resolution_tiling_test"
+package = types.ModuleType(PACKAGE_NAME)
+package.__path__ = [str(CUSTOM_NODE_ROOT)]
+sys.modules.setdefault(PACKAGE_NAME, package)
+
+from utils_collection_high_resolution_tiling_test.image_nodes import (
+    HighResolutionTileLayout,
+    UC_HighResolutionTileAccumulator,
+    UC_HighResolutionTileSplit,
+)
+from utils_collection_high_resolution_tiling_test.tile_helpers import (
+    accumulate_tile_images,
+    build_tile_records,
+    split_and_encode_tiles,
+    tile_weight_mask,
+)
+
+
+class MockVAE:
+    def __init__(self, compression=8):
+        self.compression = compression
+        self.calls = []
+
+    def spacial_compression_encode(self):
+        return self.compression
+
+    def encode(self, image):
+        self.calls.append(tuple(image.shape))
+        return torch.zeros(
+            (
+                image.shape[0],
+                4,
+                image.shape[1] // self.compression,
+                image.shape[2] // self.compression,
+            ),
+            dtype=image.dtype,
+            device=image.device,
+        )
+
+
+def _split(image, vae=None, **overrides):
+    settings = {
+        "tile_mode": "tile_size",
+        "tile_width": 8,
+        "tile_height": 8,
+        "rows": 2,
+        "columns": 2,
+        "overlap": 2,
+        "mask_profile": "cosine",
+        "feather_width": 1.0,
+        "mask_strength": 1.0,
+    }
+    settings.update(overrides)
+    return split_and_encode_tiles(image, vae or MockVAE(), **settings)
+
+
+def test_public_schema_and_list_contract():
+    split_schema = UC_HighResolutionTileSplit.define_schema()
+    accumulator_schema = UC_HighResolutionTileAccumulator.define_schema()
+
+    assert split_schema.node_id == "UC_HighResolutionTileSplit"
+    assert split_schema.display_name == "High Resolution Tile Split & VAE Encode"
+    assert [output.id for output in split_schema.outputs] == [
+        "tile_images",
+        "tile_latents",
+        "tile_layout",
+    ]
+    assert [output.is_output_list for output in split_schema.outputs] == [
+        True,
+        True,
+        False,
+    ]
+    assert split_schema.outputs[2].io_type == "UC_HIGH_RES_TILE_LAYOUT"
+    assert HighResolutionTileLayout.io_type == "UC_HIGH_RES_TILE_LAYOUT"
+
+    assert accumulator_schema.node_id == "UC_HighResolutionTileAccumulator"
+    assert accumulator_schema.display_name == "High Resolution Tile Accumulator"
+    assert accumulator_schema.is_input_list is True
+    assert [value.id for value in accumulator_schema.inputs] == [
+        "images",
+        "tile_layout",
+    ]
+
+
+def test_fixed_size_coordinates_preserve_exact_overlap_and_row_major_order():
+    records, rows, columns = build_tile_records(
+        height=10,
+        width=14,
+        tile_mode="tile_size",
+        tile_width=8,
+        tile_height=8,
+        rows=99,
+        columns=99,
+        overlap=2,
+    )
+
+    assert (rows, columns) == (2, 2)
+    assert [
+        (record["x0"], record["y0"], record["x1"], record["y1"])
+        for record in records
+    ] == [
+        (0, 0, 8, 8),
+        (6, 0, 14, 8),
+        (0, 6, 8, 10),
+        (6, 6, 14, 10),
+    ]
+    assert records[0]["right_overlap"] == 2
+    assert records[1]["left_overlap"] == 2
+    assert records[0]["bottom_overlap"] == 2
+    assert records[2]["top_overlap"] == 2
+
+
+def test_grid_coordinates_use_requested_shared_overlap():
+    records, rows, columns = build_tile_records(
+        height=13,
+        width=17,
+        tile_mode="grid",
+        tile_width=1,
+        tile_height=1,
+        rows=2,
+        columns=3,
+        overlap=2,
+    )
+
+    assert (rows, columns) == (2, 3)
+    assert len(records) == 6
+    for record in records:
+        if record["column"] > 0:
+            assert record["left_overlap"] == 2
+        if record["column"] < columns - 1:
+            assert record["right_overlap"] == 2
+        if record["row"] > 0:
+            assert record["top_overlap"] == 2
+        if record["row"] < rows - 1:
+            assert record["bottom_overlap"] == 2
+
+
+@pytest.mark.parametrize("profile", ["linear", "cosine"])
+def test_masks_protect_only_internal_edges(profile):
+    record = {
+        "height": 6,
+        "width": 8,
+        "left_overlap": 0,
+        "right_overlap": 4,
+        "top_overlap": 0,
+        "bottom_overlap": 0,
+    }
+    mask = tile_weight_mask(
+        record,
+        profile,
+        feather_width=1.0,
+        strength=1.0,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+
+    assert mask.shape == (6, 8)
+    assert torch.all(mask[:, :4] == 1)
+    assert torch.all(mask[:, -1] == 0)
+    assert torch.all(mask[:, -4] == 1)
+
+
+def test_mask_strength_controls_protected_edge_floor():
+    record = {
+        "height": 4,
+        "width": 6,
+        "left_overlap": 3,
+        "right_overlap": 0,
+        "top_overlap": 0,
+        "bottom_overlap": 0,
+    }
+    mask = tile_weight_mask(
+        record,
+        "linear",
+        feather_width=1.0,
+        strength=0.25,
+        device=torch.device("cpu"),
+        dtype=torch.float32,
+    )
+
+    assert torch.allclose(mask[:, 0], torch.full((4,), 0.75))
+    assert torch.all(mask[:, -1] == 1)
+
+
+def test_feather_width_changes_transition_geometry():
+    record = {
+        "height": 2,
+        "width": 8,
+        "left_overlap": 0,
+        "right_overlap": 4,
+        "top_overlap": 0,
+        "bottom_overlap": 0,
+    }
+    full = tile_weight_mask(
+        record, "linear", 1.0, 1.0, torch.device("cpu"), torch.float32
+    )
+    half = tile_weight_mask(
+        record, "linear", 0.5, 1.0, torch.device("cpu"), torch.float32
+    )
+
+    assert full[0, -3] < 1
+    assert half[0, -3] == 1
+    assert full[0, -1] == half[0, -1] == 0
+
+
+def test_split_encodes_each_tile_sequentially_and_attaches_masks():
+    image = torch.rand(1, 10, 14, 3)
+    vae = MockVAE(compression=8)
+    images, latents, layout = _split(image, vae)
+
+    assert len(images) == len(latents) == len(layout["tiles"]) == 4
+    assert all(call[0] == 1 for call in vae.calls)
+    assert vae.calls == [
+        (1, 8, 8, 3),
+        (1, 8, 8, 3),
+        (1, 8, 8, 3),
+        (1, 8, 8, 3),
+    ]
+    assert images[2].shape == (1, 4, 8, 3)
+    assert latents[2]["samples"].shape == (1, 4, 1, 1)
+    assert latents[2]["noise_mask"].shape == (1, 1, 8, 8)
+    assert torch.all(latents[2]["noise_mask"][:, :, 4:, :] == 0)
+
+
+@pytest.mark.parametrize(
+    ("shape", "settings"),
+    [
+        (
+            (1, 19, 23, 3),
+            {
+                "tile_mode": "tile_size",
+                "tile_width": 12,
+                "tile_height": 11,
+                "overlap": 4,
+            },
+        ),
+        (
+            (1, 13, 17, 3),
+            {
+                "tile_mode": "grid",
+                "rows": 2,
+                "columns": 3,
+                "overlap": 2,
+            },
+        ),
+        (
+            (1, 7, 11, 3),
+            {
+                "tile_mode": "tile_size",
+                "tile_width": 32,
+                "tile_height": 32,
+                "overlap": 4,
+            },
+        ),
+    ],
+)
+def test_identity_tiles_reconstruct_exact_source(shape, settings):
+    image = torch.rand(shape, dtype=torch.float64)
+    images, _, layout = _split(image, **settings)
+
+    reconstructed = accumulate_tile_images(images, [layout])
+
+    assert reconstructed.shape == image.shape
+    assert reconstructed.dtype == image.dtype
+    assert torch.allclose(reconstructed, image, atol=1e-6)
+
+
+def test_accumulator_normalizes_different_overlap_values():
+    image = torch.zeros(1, 8, 14, 3)
+    images, _, layout = _split(
+        image,
+        tile_width=8,
+        tile_height=8,
+        overlap=2,
+        mask_profile="linear",
+    )
+    images[0] = torch.ones_like(images[0])
+    images[1] = torch.zeros_like(images[1])
+
+    reconstructed = accumulate_tile_images(images, layout)
+
+    assert torch.all(reconstructed[:, :, :6] == 1)
+    assert torch.all(reconstructed[:, :, 8:] == 0)
+    assert torch.allclose(
+        reconstructed[0, 0, 6:8, 0],
+        torch.tensor([1.0, 0.0]),
+        atol=1e-6,
+    )
+
+
+def test_single_image_and_validation_errors_are_actionable():
+    with pytest.raises(ValueError, match="exactly one image"):
+        _split(torch.zeros(2, 16, 16, 3))
+
+    with pytest.raises(ValueError, match="smaller than tile width"):
+        _split(
+            torch.zeros(1, 16, 16, 3),
+            tile_width=8,
+            tile_height=8,
+            overlap=8,
+        )
+
+    images, _, layout = _split(torch.zeros(1, 16, 16, 3))
+    with pytest.raises(ValueError, match="expected .* images"):
+        accumulate_tile_images(images[:-1], layout)
+
+
+def test_node_execute_returns_synchronized_outputs():
+    image = torch.rand(1, 8, 14, 3)
+    output = UC_HighResolutionTileSplit.execute(
+        image,
+        MockVAE(),
+        "tile_size",
+        8,
+        8,
+        2,
+        2,
+        2,
+        "cosine",
+        1.0,
+        1.0,
+    ).args
+
+    assert len(output[0]) == len(output[1]) == len(output[2]["tiles"]) == 2
+    merged = UC_HighResolutionTileAccumulator.execute(
+        output[0],
+        [output[2]],
+    ).args[0]
+    assert torch.allclose(merged, image, atol=1e-6)

--- a/tests/test_high_resolution_tiling_guide.py
+++ b/tests/test_high_resolution_tiling_guide.py
@@ -1,0 +1,65 @@
+import pathlib
+import sys
+import types
+
+
+CUSTOM_NODE_ROOT = pathlib.Path(__file__).parents[1]
+PACKAGE_NAME = "utils_collection_high_resolution_tiling_guide_test"
+package = types.ModuleType(PACKAGE_NAME)
+package.__path__ = [str(CUSTOM_NODE_ROOT)]
+sys.modules.setdefault(PACKAGE_NAME, package)
+
+from comfy.cli_args import args as cli_args
+
+prior_cpu = cli_args.cpu
+cli_args.cpu = True
+try:
+    from utils_collection_high_resolution_tiling_guide_test.utils_nodes import (
+        UC_HighResolutionTilingGuide,
+    )
+finally:
+    cli_args.cpu = prior_cpu
+
+
+EXPECTED_TOPICS = [
+    "workflow",
+    "split_settings",
+    "overlap_masks",
+    "visual_conditioning",
+    "sampling",
+    "accumulation",
+]
+
+
+def test_high_resolution_tiling_guide_schema_and_topics():
+    schema = UC_HighResolutionTilingGuide.define_schema()
+    topic_input = {value.id: value for value in schema.inputs}["topic"]
+
+    assert schema.node_id == "UC_HighResolutionTilingGuide"
+    assert schema.display_name == "High Resolution Tiling Guide"
+    assert topic_input.options == EXPECTED_TOPICS
+    assert topic_input.default == "workflow"
+    for topic in EXPECTED_TOPICS:
+        markdown = UC_HighResolutionTilingGuide.execute(topic).args[0]
+        assert markdown.startswith("## ")
+        assert "Unknown topic" not in markdown
+
+
+def test_high_resolution_tiling_guide_documents_execution_contract():
+    workflow = UC_HighResolutionTilingGuide.execute("workflow").args[0]
+    masks = UC_HighResolutionTilingGuide.execute("overlap_masks").args[0]
+    conditioning = UC_HighResolutionTilingGuide.execute(
+        "visual_conditioning"
+    ).args[0]
+    sampling = UC_HighResolutionTilingGuide.execute("sampling").args[0]
+    accumulation = UC_HighResolutionTilingGuide.execute("accumulation").args[0]
+
+    assert "true ComfyUI lists" in workflow
+    assert "non-overlapping interior is solid `1.0`" in masks
+    assert "paired by index" in conditioning
+    assert "full-image caption" in conditioning
+    assert "`advanced` uses the KJNodes-compatible threshold multiplier" in sampling
+    assert "Connect its `model` output to the sampler guider" in sampling
+    assert "`differential_diffusion_value` is mode-dependent" in sampling
+    assert "does not implement a sampler" in sampling
+    assert "exactly the tiles described by that layout" in accumulation

--- a/tests/test_markdown_preview.py
+++ b/tests/test_markdown_preview.py
@@ -1,0 +1,59 @@
+import json
+import pathlib
+import sys
+import types
+
+
+CUSTOM_NODE_ROOT = pathlib.Path(__file__).parents[1]
+PACKAGE_NAME = "utils_collection_markdown_preview_test"
+package = types.ModuleType(PACKAGE_NAME)
+package.__path__ = [str(CUSTOM_NODE_ROOT)]
+sys.modules.setdefault(PACKAGE_NAME, package)
+
+from comfy.cli_args import args as cli_args
+
+prior_cpu = cli_args.cpu
+cli_args.cpu = True
+try:
+    from utils_collection_markdown_preview_test.utils_nodes import (
+        UC_MarkdownPreview,
+    )
+finally:
+    cli_args.cpu = prior_cpu
+
+
+def test_markdown_preview_schema_is_permanent_markdown_output_node():
+    schema = UC_MarkdownPreview.define_schema()
+
+    assert schema.node_id == "UC_MarkdownPreview"
+    assert schema.display_name == "Preview as Markdown"
+    assert schema.is_output_node is True
+    assert [value.id for value in schema.inputs] == ["source"]
+    assert [value.id for value in schema.outputs] == ["text"]
+
+
+def test_markdown_preview_returns_ui_markdown_and_text_output():
+    markdown = "## Heading\n\n- one\n- two"
+    output = UC_MarkdownPreview.execute(markdown)
+
+    assert output.args == (markdown,)
+    assert output.ui == {"markdown": (markdown,)}
+
+
+def test_markdown_preview_serializes_non_string_values():
+    source = {"enabled": True, "items": [1, 2]}
+    expected = json.dumps(source, indent=2)
+    output = UC_MarkdownPreview.execute(source)
+
+    assert output.args == (expected,)
+    assert output.ui == {"markdown": (expected,)}
+
+
+def test_markdown_preview_frontend_uses_core_markdown_widget():
+    frontend = (CUSTOM_NODE_ROOT / "web" / "markdown_preview.js").read_text(
+        encoding="utf-8"
+    )
+
+    assert 'nodeData.name !== "UC_MarkdownPreview"' in frontend
+    assert "ComfyWidgets.MARKDOWN(" in frontend
+    assert "preview_mode" not in frontend

--- a/tile_helpers.py
+++ b/tile_helpers.py
@@ -7,6 +7,59 @@ import torch.nn.functional as F
 TILE_LAYOUT_FORMAT_VERSION = 1
 TILE_MODES = ("tile_size", "grid")
 TILE_MASK_PROFILES = ("cosine", "linear")
+TILE_DIFFERENTIAL_DIFFUSION_MODES = ("off", "core", "advanced")
+
+
+def apply_tile_differential_diffusion(
+    model,
+    mode,
+    value,
+):
+    if mode not in TILE_DIFFERENTIAL_DIFFUSION_MODES:
+        raise ValueError(f"Unsupported tile Differential Diffusion mode: {mode}.")
+    if mode == "off":
+        return model
+    if model is None:
+        raise ValueError(
+            "Connect a model when tile Differential Diffusion is enabled."
+        )
+    if mode == "core":
+        strength = float(value)
+        if not 0.0 <= strength <= 1.0:
+            raise ValueError(
+                "Core Differential Diffusion value must be between 0.0 and 1.0."
+            )
+        from comfy_extras.nodes_differential_diffusion import DifferentialDiffusion
+
+        return DifferentialDiffusion.execute(model, strength).args[0]
+
+    multiplier = float(value)
+    if multiplier == 0.0:
+        raise ValueError(
+            "Advanced Differential Diffusion multiplier cannot be zero."
+        )
+
+    patched_model = model.clone()
+
+    def advanced_mask(sigma, denoise_mask, extra_options):
+        sampling = extra_options["model"].inner_model.model_sampling
+        step_sigmas = extra_options["sigmas"]
+        sigma_to = sampling.sigma_min
+        if step_sigmas[-1] > sigma_to:
+            sigma_to = step_sigmas[-1]
+        sigma_from = step_sigmas[0]
+        timestep_from = sampling.timestep(sigma_from)
+        timestep_to = sampling.timestep(sigma_to)
+        current_timestep = sampling.timestep(sigma[0])
+        threshold = (
+            (current_timestep - timestep_to)
+            / (timestep_from - timestep_to)
+            / multiplier
+        )
+        return (denoise_mask >= threshold).to(denoise_mask.dtype)
+
+    patched_model.set_model_denoise_mask_function(advanced_mask)
+    return patched_model
 
 
 def _validate_common_tiling_inputs(
@@ -277,8 +330,15 @@ def split_and_encode_tiles(
         ]
         padded_tile, pad_bottom, pad_right = _pad_tile_for_vae(tile, compression)
         samples = vae.encode(padded_tile)
-        if not torch.is_tensor(samples) or samples.ndim != 4 or samples.shape[0] != 1:
-            raise ValueError("The VAE must return one four-dimensional latent per tile.")
+        if (
+            not torch.is_tensor(samples)
+            or samples.ndim not in (4, 5)
+            or samples.shape[0] != 1
+            or (samples.ndim == 5 and samples.shape[2] != 1)
+        ):
+            raise ValueError(
+                "The VAE must return one spatial latent per image tile."
+            )
 
         mask = tile_weight_mask(
             record,

--- a/tile_helpers.py
+++ b/tile_helpers.py
@@ -1,0 +1,409 @@
+import math
+
+import torch
+import torch.nn.functional as F
+
+
+TILE_LAYOUT_FORMAT_VERSION = 1
+TILE_MODES = ("tile_size", "grid")
+TILE_MASK_PROFILES = ("cosine", "linear")
+
+
+def _validate_common_tiling_inputs(
+    image,
+    tile_mode,
+    tile_width,
+    tile_height,
+    rows,
+    columns,
+    overlap,
+    mask_profile,
+    feather_width,
+    mask_strength,
+):
+    if not torch.is_tensor(image) or image.ndim != 4:
+        raise ValueError("Tiled sampling requires one BHWC IMAGE tensor.")
+    if image.shape[0] != 1:
+        raise ValueError("Tiled sampling accepts exactly one image, not an image batch.")
+    if image.shape[1] < 1 or image.shape[2] < 1:
+        raise ValueError("Tiled sampling requires positive image dimensions.")
+    if tile_mode not in TILE_MODES:
+        raise ValueError(f"Unsupported tile mode: {tile_mode}.")
+    if mask_profile not in TILE_MASK_PROFILES:
+        raise ValueError(f"Unsupported tile mask profile: {mask_profile}.")
+    if overlap < 0:
+        raise ValueError("Tile overlap cannot be negative.")
+    if not 0.0 <= feather_width <= 1.0:
+        raise ValueError("Mask feather width must be between 0.0 and 1.0.")
+    if not 0.0 <= mask_strength <= 1.0:
+        raise ValueError("Mask strength must be between 0.0 and 1.0.")
+    if tile_mode == "tile_size":
+        if tile_width < 1 or tile_height < 1:
+            raise ValueError("Tile width and height must be positive.")
+        if overlap >= tile_width or overlap >= tile_height:
+            raise ValueError("Tile overlap must be smaller than tile width and height.")
+    else:
+        if rows < 1 or columns < 1:
+            raise ValueError("Tile rows and columns must be positive.")
+
+
+def _fixed_axis_ranges(length, tile_size, overlap):
+    if tile_size >= length:
+        return [(0, length)]
+    stride = tile_size - overlap
+    ranges = []
+    start = 0
+    while start < length:
+        end = min(start + tile_size, length)
+        ranges.append((start, end))
+        if end == length:
+            break
+        start += stride
+    return ranges
+
+
+def _grid_axis_ranges(length, count, overlap):
+    edges = [round(index * length / count) for index in range(count + 1)]
+    left_halo = overlap // 2
+    right_halo = overlap - left_halo
+    ranges = []
+    for index in range(count):
+        start = edges[index]
+        end = edges[index + 1]
+        if index > 0:
+            start = max(0, start - left_halo)
+        if index < count - 1:
+            end = min(length, end + right_halo)
+        if end <= start:
+            raise ValueError(
+                "Tile grid is too dense for this image; reduce rows or columns."
+            )
+        ranges.append((start, end))
+    return ranges
+
+
+def _axis_neighbor_overlaps(ranges, index):
+    start, end = ranges[index]
+    left = max(0, ranges[index - 1][1] - start) if index > 0 else 0
+    right = max(0, end - ranges[index + 1][0]) if index + 1 < len(ranges) else 0
+    return left, right
+
+
+def build_tile_records(
+    height,
+    width,
+    tile_mode,
+    tile_width,
+    tile_height,
+    rows,
+    columns,
+    overlap,
+):
+    if tile_mode == "tile_size":
+        x_ranges = _fixed_axis_ranges(width, tile_width, overlap)
+        y_ranges = _fixed_axis_ranges(height, tile_height, overlap)
+    else:
+        if rows > height or columns > width:
+            raise ValueError(
+                "Tile rows and columns cannot exceed the source pixel dimensions."
+            )
+        min_cell_width = min(
+            round((index + 1) * width / columns) - round(index * width / columns)
+            for index in range(columns)
+        )
+        min_cell_height = min(
+            round((index + 1) * height / rows) - round(index * height / rows)
+            for index in range(rows)
+        )
+        if (columns > 1 and overlap >= min_cell_width) or (
+            rows > 1 and overlap >= min_cell_height
+        ):
+            raise ValueError(
+                "Tile overlap must be smaller than every grid cell dimension."
+            )
+        x_ranges = _grid_axis_ranges(width, columns, overlap)
+        y_ranges = _grid_axis_ranges(height, rows, overlap)
+
+    records = []
+    for row, (y0, y1) in enumerate(y_ranges):
+        top_overlap, bottom_overlap = _axis_neighbor_overlaps(y_ranges, row)
+        for column, (x0, x1) in enumerate(x_ranges):
+            left_overlap, right_overlap = _axis_neighbor_overlaps(x_ranges, column)
+            records.append(
+                {
+                    "index": len(records),
+                    "row": row,
+                    "column": column,
+                    "x0": x0,
+                    "y0": y0,
+                    "x1": x1,
+                    "y1": y1,
+                    "width": x1 - x0,
+                    "height": y1 - y0,
+                    "left_overlap": left_overlap,
+                    "right_overlap": right_overlap,
+                    "top_overlap": top_overlap,
+                    "bottom_overlap": bottom_overlap,
+                }
+            )
+    return records, len(y_ranges), len(x_ranges)
+
+
+def _profile_ramp(length, low, high, profile, device, dtype):
+    if length <= 0:
+        return torch.empty(0, device=device, dtype=dtype)
+    unit = torch.linspace(0.0, 1.0, length, device=device, dtype=dtype)
+    if profile == "cosine":
+        unit = 0.5 - 0.5 * torch.cos(unit * math.pi)
+    return low + (high - low) * unit
+
+
+def tile_weight_mask(record, profile, feather_width, strength, device, dtype):
+    height = int(record["height"])
+    width = int(record["width"])
+    floor = 1.0 - float(strength)
+    y_weight = torch.ones(height, device=device, dtype=dtype)
+    x_weight = torch.ones(width, device=device, dtype=dtype)
+
+    side_specs = (
+        (x_weight, int(record["left_overlap"]), True),
+        (x_weight, int(record["right_overlap"]), False),
+        (y_weight, int(record["top_overlap"]), True),
+        (y_weight, int(record["bottom_overlap"]), False),
+    )
+    for axis_weight, actual_overlap, rising in side_specs:
+        if actual_overlap <= 0 or strength <= 0.0:
+            continue
+        feather = min(
+            actual_overlap,
+            max(1, round(actual_overlap * float(feather_width))),
+        )
+        ramp = _profile_ramp(
+            feather,
+            floor if rising else 1.0,
+            1.0 if rising else floor,
+            profile,
+            device,
+            dtype,
+        )
+        if rising:
+            axis_weight[:feather] *= ramp
+        else:
+            axis_weight[-feather:] *= ramp
+
+    return y_weight[:, None] * x_weight[None, :]
+
+
+def _vae_compression(vae):
+    compression = vae.spacial_compression_encode()
+    if isinstance(compression, bool):
+        raise ValueError("The connected VAE returned an invalid spatial compression.")
+    try:
+        compression = int(compression)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "The connected VAE does not expose a valid spatial compression."
+        ) from exc
+    if compression < 1:
+        raise ValueError("The connected VAE returned an invalid spatial compression.")
+    return compression
+
+
+def _pad_tile_for_vae(tile, compression):
+    height, width = tile.shape[1:3]
+    padded_height = math.ceil(height / compression) * compression
+    padded_width = math.ceil(width / compression) * compression
+    pad_bottom = padded_height - height
+    pad_right = padded_width - width
+    if pad_bottom == 0 and pad_right == 0:
+        return tile, pad_bottom, pad_right
+    padded = F.pad(
+        tile.movedim(-1, 1),
+        (0, pad_right, 0, pad_bottom),
+        mode="replicate",
+    ).movedim(1, -1)
+    return padded, pad_bottom, pad_right
+
+
+def split_and_encode_tiles(
+    image,
+    vae,
+    tile_mode,
+    tile_width,
+    tile_height,
+    rows,
+    columns,
+    overlap,
+    mask_profile,
+    feather_width,
+    mask_strength,
+):
+    _validate_common_tiling_inputs(
+        image,
+        tile_mode,
+        tile_width,
+        tile_height,
+        rows,
+        columns,
+        overlap,
+        mask_profile,
+        feather_width,
+        mask_strength,
+    )
+    if vae is None:
+        raise ValueError("Connect a VAE to encode the image tiles.")
+
+    height, width = image.shape[1:3]
+    records, actual_rows, actual_columns = build_tile_records(
+        height,
+        width,
+        tile_mode,
+        tile_width,
+        tile_height,
+        rows,
+        columns,
+        overlap,
+    )
+    compression = _vae_compression(vae)
+    image_tiles = []
+    latent_tiles = []
+
+    for record in records:
+        tile = image[
+            :,
+            record["y0"]:record["y1"],
+            record["x0"]:record["x1"],
+            :,
+        ]
+        padded_tile, pad_bottom, pad_right = _pad_tile_for_vae(tile, compression)
+        samples = vae.encode(padded_tile)
+        if not torch.is_tensor(samples) or samples.ndim != 4 or samples.shape[0] != 1:
+            raise ValueError("The VAE must return one four-dimensional latent per tile.")
+
+        mask = tile_weight_mask(
+            record,
+            mask_profile,
+            feather_width,
+            mask_strength,
+            device=padded_tile.device,
+            dtype=padded_tile.dtype,
+        )
+        if pad_bottom or pad_right:
+            mask = F.pad(mask, (0, pad_right, 0, pad_bottom), value=0.0)
+        record["pad_bottom"] = pad_bottom
+        record["pad_right"] = pad_right
+        record["encoded_width"] = padded_tile.shape[2]
+        record["encoded_height"] = padded_tile.shape[1]
+        image_tiles.append(tile)
+        latent_tiles.append(
+            {
+                "samples": samples,
+                "noise_mask": mask.unsqueeze(0).unsqueeze(0),
+            }
+        )
+
+    layout = {
+        "format": "UC_HIGH_RES_TILE_LAYOUT",
+        "version": TILE_LAYOUT_FORMAT_VERSION,
+        "original_height": height,
+        "original_width": width,
+        "channels": image.shape[-1],
+        "tile_mode": tile_mode,
+        "rows": actual_rows,
+        "columns": actual_columns,
+        "overlap": overlap,
+        "mask_profile": mask_profile,
+        "feather_width": float(feather_width),
+        "mask_strength": float(mask_strength),
+        "vae_compression": compression,
+        "tiles": records,
+    }
+    return image_tiles, latent_tiles, layout
+
+
+def _unwrap_layout(layout_values):
+    if isinstance(layout_values, list):
+        non_null = [value for value in layout_values if value is not None]
+        if not non_null:
+            raise ValueError("Tile layout metadata is missing.")
+        layout = non_null[0]
+        if any(value != layout for value in non_null[1:]):
+            raise ValueError("Tile accumulator received conflicting layout metadata.")
+        return layout
+    return layout_values
+
+
+def validate_tile_layout(layout):
+    if not isinstance(layout, dict):
+        raise ValueError("Tile layout metadata is invalid.")
+    if layout.get("format") != "UC_HIGH_RES_TILE_LAYOUT":
+        raise ValueError("Tile layout metadata has an unsupported type.")
+    if layout.get("version") != TILE_LAYOUT_FORMAT_VERSION:
+        raise ValueError("Tile layout metadata has an unsupported version.")
+    records = layout.get("tiles")
+    if not isinstance(records, list) or not records:
+        raise ValueError("Tile layout metadata contains no tiles.")
+    return records
+
+
+def accumulate_tile_images(image_values, layout_values):
+    layout = _unwrap_layout(layout_values)
+    records = validate_tile_layout(layout)
+    images = [image for image in image_values if image is not None]
+    if len(images) != len(records):
+        raise ValueError(
+            f"Tile accumulator expected {len(records)} images but received {len(images)}."
+        )
+
+    first = images[0]
+    if not torch.is_tensor(first) or first.ndim != 4 or first.shape[0] != 1:
+        raise ValueError("Every accumulated tile must be one BHWC IMAGE tensor.")
+    device = first.device
+    dtype = first.dtype
+    channels = first.shape[-1]
+    canvas = torch.zeros(
+        (1, layout["original_height"], layout["original_width"], channels),
+        device=device,
+        dtype=dtype,
+    )
+    weights = torch.zeros(
+        (1, layout["original_height"], layout["original_width"], 1),
+        device=device,
+        dtype=dtype,
+    )
+
+    for image, record in zip(images, records):
+        if (
+            not torch.is_tensor(image)
+            or image.ndim != 4
+            or image.shape[0] != 1
+        ):
+            raise ValueError("Every accumulated tile must be one BHWC IMAGE tensor.")
+        if image.device != device or image.dtype != dtype:
+            raise ValueError("All accumulated tiles must share a device and dtype.")
+        if image.shape[-1] != channels:
+            raise ValueError("All accumulated tiles must have matching channels.")
+        real_height = int(record["height"])
+        real_width = int(record["width"])
+        if image.shape[1] < real_height or image.shape[2] < real_width:
+            raise ValueError(
+                f"Decoded tile {record['index']} is smaller than its recorded region."
+            )
+
+        cropped = image[:, :real_height, :real_width, :]
+        mask = tile_weight_mask(
+            record,
+            layout["mask_profile"],
+            layout["feather_width"],
+            layout["mask_strength"],
+            device=device,
+            dtype=dtype,
+        ).unsqueeze(0).unsqueeze(-1)
+        y0, y1 = record["y0"], record["y1"]
+        x0, x1 = record["x0"], record["x1"]
+        canvas[:, y0:y1, x0:x1, :] += cropped * mask
+        weights[:, y0:y1, x0:x1, :] += mask
+
+    if torch.any(weights <= 0):
+        raise ValueError("Tile layout left uncovered output pixels.")
+    return canvas / weights

--- a/utils_nodes.py
+++ b/utils_nodes.py
@@ -1341,6 +1341,88 @@ class UC_CompositeNodesGuide(io.ComfyNode):
         return io.NodeOutput(topics.get(topic, "Unknown topic selected."))
 
 
+class UC_HighResolutionTilingGuide(io.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="UC_HighResolutionTilingGuide",
+            display_name="High Resolution Tiling Guide",
+            category="utils/documentation",
+            inputs=[
+                io.Combo.Input(
+                    "topic",
+                    options=[
+                        "workflow",
+                        "split_settings",
+                        "overlap_masks",
+                        "visual_conditioning",
+                        "sampling",
+                        "accumulation",
+                    ],
+                    default="workflow",
+                    tooltip="Select the high-resolution tiled workflow topic.",
+                ),
+            ],
+            outputs=[io.String.Output(display_name="markdown")],
+        )
+
+    @classmethod
+    def execute(cls, topic: str) -> io.NodeOutput:
+        topics = {
+            "workflow": (
+                "## High-resolution tiled workflow\n\n"
+                "1. Upscale or otherwise prepare one complete source image.\n"
+                "2. Connect it and the generation VAE to `UC_HighResolutionTileSplit`.\n"
+                "3. Send `tile images` through any list-mapped image processing and visual-conditioning branches.\n"
+                "4. Send `tile latents` to the latent input of a Core sampler. ComfyUI pairs image conditioning and latents by list index.\n"
+                "5. Decode the sampled latent list with the same VAE.\n"
+                "6. Connect the decoded image list and the original `tile layout` to `UC_HighResolutionTileAccumulator`.\n\n"
+                "The splitter accepts one source image. It VAE-encodes tiles sequentially and returns true ComfyUI lists so downstream nodes execute once per tile."
+            ),
+            "split_settings": (
+                "## Split settings\n\n"
+                "- `tile_mode=tile_size` uses `tile_width` and `tile_height`; `rows` and `columns` are ignored.\n"
+                "- `tile_mode=grid` uses `rows` and `columns`; `tile_width` and `tile_height` are ignored.\n"
+                "- `overlap` is the number of source-image pixels shared by adjacent tiles on both axes.\n"
+                "- Tile-size mode advances by tile dimension minus overlap. Edge tiles are padded only as required for VAE compression.\n"
+                "- Grid mode divides the complete image into the requested cells and adds overlap around internal cell boundaries.\n\n"
+                "More overlap provides a wider transition area but processes more pixels. Overlap must remain smaller than the applicable tile or grid-cell dimension."
+            ),
+            "overlap_masks": (
+                "## Overlap masks\n\n"
+                "Every latent contains a Core-compatible `noise_mask`. The non-overlapping interior is solid `1.0`. Only edges shared with neighboring tiles are feathered; outer image boundaries remain solid.\n\n"
+                "- `mask_profile=cosine` uses an eased transition. `linear` uses a constant-rate transition.\n"
+                "- `feather_width` selects the fraction of the overlap occupied by the transition. `1.0` uses the full overlap.\n"
+                "- `mask_strength` controls the minimum at a protected shared edge. `1.0` reaches `0`; `0.5` reaches `0.5`; `0.0` leaves the mask solid.\n\n"
+                "These masks are also the normalized reconstruction weights used by the accumulator."
+            ),
+            "visual_conditioning": (
+                "## Visual conditioning and image lists\n\n"
+                "Connecting `tile images` to `UC_AdvancedVisualConditioningEncode` executes that encoder once per tile.\n\n"
+                "Two image lists connected to two image sockets are paired by index. For example, an original tile list and its radius-2 blurred list become `(original 0, blurred 0)`, `(original 1, blurred 1)`, and so on. With a visual fusion configuration, each pair follows that fusion method.\n\n"
+                "Lists are not combined across tile indices. If list lengths differ, standard ComfyUI mapping repeats the final item of the shorter list. A shared text prompt is broadcast to every tile, so a full-image caption can introduce globally described subjects into every tile."
+            ),
+            "sampling": (
+                "## Sampling the tile list\n\n"
+                "Connect the conditioning list and `tile latents` to the ordinary Core sampling path. Matching indices are sampled together.\n\n"
+                "The sigma schedule controls overall change, including the solid non-overlap interiors. Lowering its start sigma generally preserves more of each encoded tile.\n\n"
+                "The splitter can optionally apply Differential Diffusion to a connected model. Connect its `model` output to the sampler guider. `off` returns the connected model unchanged, `core` uses ComfyUI Core Differential Diffusion, and `advanced` uses the KJNodes-compatible threshold multiplier. The model input is required only when either active mode is selected.\n\n"
+                "`differential_diffusion_value` is mode-dependent:\n\n"
+                "- In `core` mode it is strength from `0` through `1`, blending Core's progressive binary mask with the original soft mask.\n"
+                "- In `advanced` mode it is the KJNodes-compatible threshold divisor from `-10` through `10`; it cannot be zero.\n"
+                "- Differential Diffusion does not replace sigma selection; start sigma still controls overall change in solid non-overlap interiors.\n\n"
+                "The splitter still does not implement a sampler or noise generator. A single noise-provider connection is broadcast to every mapped tile execution."
+            ),
+            "accumulation": (
+                "## Decoding and accumulation\n\n"
+                "Decode the sampled latent list with the same VAE used by the splitter. Connect that decoded image list to `images` and connect the splitter's matching `tile layout` directly to the accumulator.\n\n"
+                "`UC_HighResolutionTileAccumulator` consumes the complete image list in one execution. It removes VAE padding, places every tile at its recorded source coordinates, applies the stored feather weights, and normalizes overlapping contributions.\n\n"
+                "Do not reorder, omit, or insert list items before accumulation. The image list must contain exactly the tiles described by that layout."
+            ),
+        }
+        return io.NodeOutput(topics.get(topic, "Unknown topic selected."))
+
+
 EncoderNodesGuide = UC_EncoderNodesGuide
 CompositeNodesGuide = UC_CompositeNodesGuide
 

--- a/utils_nodes.py
+++ b/utils_nodes.py
@@ -1423,6 +1423,38 @@ class UC_HighResolutionTilingGuide(io.ComfyNode):
         return io.NodeOutput(topics.get(topic, "Unknown topic selected."))
 
 
+class UC_MarkdownPreview(io.ComfyNode):
+    @classmethod
+    def define_schema(cls) -> io.Schema:
+        return io.Schema(
+            node_id="UC_MarkdownPreview",
+            display_name="Preview as Markdown",
+            category="utils/documentation",
+            description="Displays a connected value using the Core Markdown renderer.",
+            inputs=[
+                io.AnyType.Input(
+                    "source",
+                    tooltip="Text or another serializable value to render as Markdown.",
+                ),
+            ],
+            outputs=[io.String.Output("text", display_name="text")],
+            is_output_node=True,
+        )
+
+    @classmethod
+    def execute(cls, source=None) -> io.NodeOutput:
+        if isinstance(source, str):
+            value = source
+        elif isinstance(source, (int, float, bool)) or source is None:
+            value = str(source)
+        else:
+            try:
+                value = json.dumps(source, indent=2)
+            except (TypeError, ValueError):
+                value = str(source)
+        return io.NodeOutput(value, ui={"markdown": (value,)})
+
+
 EncoderNodesGuide = UC_EncoderNodesGuide
 CompositeNodesGuide = UC_CompositeNodesGuide
 

--- a/web/markdown_preview.js
+++ b/web/markdown_preview.js
@@ -1,0 +1,39 @@
+import { app } from "../../scripts/app.js";
+import { ComfyWidgets } from "../../scripts/widgets.js";
+
+app.registerExtension({
+  name: "ComfyUI.UtilsCollection.MarkdownPreview",
+  async beforeRegisterNodeDef(nodeType, nodeData) {
+    if (nodeData.name !== "UC_MarkdownPreview") return;
+
+    const onNodeCreated = nodeType.prototype.onNodeCreated;
+    nodeType.prototype.onNodeCreated = function () {
+      const result = onNodeCreated?.apply(this, arguments);
+      const markdownWidget = ComfyWidgets.MARKDOWN(
+        this,
+        "markdown",
+        ["STRING", { default: "" }],
+        app,
+      ).widget;
+      markdownWidget.serialize = true;
+      this.serialize_widgets = true;
+      this.__ucMarkdownWidget = markdownWidget;
+      this.setSize([
+        Math.max(this.size[0], 360),
+        Math.max(this.size[1], 240),
+      ]);
+      return result;
+    };
+
+    const onExecuted = nodeType.prototype.onExecuted;
+    nodeType.prototype.onExecuted = function (message) {
+      onExecuted?.apply(this, arguments);
+      const markdown = message?.markdown;
+      const value = Array.isArray(markdown) ? markdown[0] : markdown;
+      if (this.__ucMarkdownWidget && value !== undefined) {
+        this.__ucMarkdownWidget.value = String(value);
+        this.setDirtyCanvas(true, true);
+      }
+    };
+  },
+});


### PR DESCRIPTION
## Summary
- add sequential high-resolution tile splitting, VAE encoding, and overlap-aware accumulation
- preserve tile image and latent list lanes for Core sampling and visual conditioning
- support Core and KJNodes-compatible advanced Differential Diffusion from the splitter
- add a dedicated tiled-workflow guide and input-driven Markdown preview node

## Validation
- 302 repository tests passed
- focused schema, mask, list, accumulation, Differential Diffusion, guide, and Markdown preview tests
- Python compilation, relevant Ruff checks, and JavaScript syntax validation passed
- no model inference performed