### PR TITLE
fix(workflow): update VLM resolution in compositor example

### DIFF
--- a/workflows/CompositorExampleWorkflow.json
+++ b/workflows/CompositorExampleWorkflow.json
@@ -806,7 +806,7 @@
       "widgets_values": [
         "",
         "",
-        "Large (1024)",
+        384,
         "",
         "zero-pad",
         "Fast (1024)",


### PR DESCRIPTION
The compositor example was saved when `UC_AdvancedVisualConditioningEncode` used preset values for `vlm_resolution`, with `"Large (1024)"` selected. The input has since changed to an integer, but the example retained the legacy string and now loads with `NaN` in that widget.

Replace the stale value with the current default, `384`, so the example loads correctly and reflects the node's default configuration.

Validated that the workflow remains valid JSON and that this is the only changed value.
