### PR TITLE
Fix MiniMax H3 FinalLayer signature mismatch

### DIFF
--- a/patcher_helpers.py
+++ b/patcher_helpers.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import bisect
 import contextvars
 import hashlib
+import inspect
 import logging
 import math
 import os
@@ -1060,6 +1061,30 @@ def run_minimax_h3_blocks(
     return hidden_states
 
 
+def _call_minimax_h3_final_layer(
+    final_layer: Any,
+    hidden_states: torch.Tensor,
+    timestep_embedding: torch.Tensor,
+    video_seg: tuple[Any, ...],
+    audio_seg: tuple[Any, ...],
+    sigma: torch.Tensor,
+    sample_sigmas: Any,
+    shifts: tuple[float, float],
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Call Core FinalLayer with either the 4-arg or extended sigma signature."""
+    target = final_layer.forward if isinstance(final_layer, torch.nn.Module) else final_layer
+    try:
+        params = inspect.signature(target).parameters
+    except (TypeError, ValueError):
+        params = {}
+    extra: tuple[Any, ...] = ()
+    if "sigma" in params:
+        extra = (sigma, sample_sigmas, shifts)
+    return final_layer(
+        hidden_states, timestep_embedding, video_seg, audio_seg, *extra
+    )
+
+
 def minimax_h3_block_patch_forward(
     self: minimax_model.MiniMaxH3Model,
     x: list[torch.Tensor],
@@ -1272,7 +1297,8 @@ def minimax_h3_block_patch_forward(
         for start, end, kind in layout.segments
         if kind == "audio"
     )
-    video_result, audio_result = self.final_layer(
+    video_result, audio_result = _call_minimax_h3_final_layer(
+        self.final_layer,
         hidden_states,
         timestep_embedding,
         video_seg,

--- a/patcher_helpers.py
+++ b/patcher_helpers.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import bisect
 import contextvars
 import hashlib
-import inspect
 import logging
 import math
 import os
@@ -1061,30 +1060,6 @@ def run_minimax_h3_blocks(
     return hidden_states
 
 
-def _call_minimax_h3_final_layer(
-    final_layer: Any,
-    hidden_states: torch.Tensor,
-    timestep_embedding: torch.Tensor,
-    video_seg: tuple[Any, ...],
-    audio_seg: tuple[Any, ...],
-    sigma: torch.Tensor,
-    sample_sigmas: Any,
-    shifts: tuple[float, float],
-) -> tuple[torch.Tensor, torch.Tensor]:
-    """Call Core FinalLayer with either the 4-arg or extended sigma signature."""
-    target = final_layer.forward if isinstance(final_layer, torch.nn.Module) else final_layer
-    try:
-        params = inspect.signature(target).parameters
-    except (TypeError, ValueError):
-        params = {}
-    extra: tuple[Any, ...] = ()
-    if "sigma" in params:
-        extra = (sigma, sample_sigmas, shifts)
-    return final_layer(
-        hidden_states, timestep_embedding, video_seg, audio_seg, *extra
-    )
-
-
 def minimax_h3_block_patch_forward(
     self: minimax_model.MiniMaxH3Model,
     x: list[torch.Tensor],
@@ -1297,15 +1272,8 @@ def minimax_h3_block_patch_forward(
         for start, end, kind in layout.segments
         if kind == "audio"
     )
-    video_result, audio_result = _call_minimax_h3_final_layer(
-        self.final_layer,
-        hidden_states,
-        timestep_embedding,
-        video_seg,
-        audio_seg,
-        sigma_v,
-        transformer_options.get("sample_sigmas"),
-        (shift_v, shift_a),
+    video_result, audio_result = self.final_layer(
+        hidden_states, timestep_embedding, video_seg, audio_seg
     )
     video_out = minimax_model.unpatchify_video(
         video_result,

--- a/tests/test_patcher_nodes.py
+++ b/tests/test_patcher_nodes.py
@@ -600,6 +600,76 @@ def test_cached_forward_matches_current_core_audio_output_contract(monkeypatch):
     assert final_layer_args["shifts"] == (1.25, 0.75)
 
 
+def test_cached_forward_matches_current_core_final_layer_without_sigma_args(monkeypatch):
+    layout = types.SimpleNamespace(
+        signature=(1, 1, 2, 2, 1),
+        segments=[(0, 1, "text"), (1, 3, "audio"), (3, 4, "video")],
+        img_update=torch.ones(1, dtype=torch.bool),
+        audio_update=torch.ones(2, dtype=torch.bool),
+        seq_len=4,
+        position_ids=torch.zeros((4, 3)),
+    )
+    video_result = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
+    audio_result = torch.arange(1.0, 9.0).reshape(2, 4)
+    received = {}
+
+    class CurrentFinalLayer(torch.nn.Module):
+        def forward(self, x, t_emb, video_seg, audio_seg):
+            received["nargs"] = 4
+            received["video_seg"] = video_seg
+            received["audio_seg"] = audio_seg
+            return video_result, audio_result
+
+    model = types.SimpleNamespace(
+        patch_size=(1, 2, 2),
+        sigma_shift_video=1.0,
+        sigma_shift_audio=1.0,
+        hidden_size=4,
+        use_adaln_curves=False,
+        blocks=[],
+        latents_dim=1,
+        video_patch_proj=lambda rows: rows,
+        audio_patch_proj=lambda rows: rows,
+        _cond_video_rows=lambda payload, device: None,
+        _cond_audio_rows=lambda payload, device: None,
+        time_embedder=lambda values: values[:, None].expand(-1, 4),
+        rope_freqs=lambda position_ids, device: torch.zeros((1, 1)),
+        final_layer=CurrentFinalLayer(),
+    )
+    monkeypatch.setattr(
+        patcher_helpers.minimax_model,
+        "rope_rotation_table",
+        lambda frequencies, dtype: frequencies,
+    )
+
+    video = torch.zeros((1, 1, 1, 2, 2), dtype=torch.float16)
+    audio = torch.zeros((1, 4, 2, 1), dtype=torch.float16)
+    context = torch.zeros((1, 1, 4), dtype=torch.float32)
+
+    output = patcher_helpers.minimax_h3_block_patch_forward(
+        model,
+        [video, audio],
+        torch.tensor([500.0]),
+        context,
+        transformer_options={
+            "sample_sigmas": torch.tensor([1.0, 0.5, 0.0]),
+            "minimax_h3_sigma_shift_video": 1.25,
+            "minimax_h3_sigma_shift_audio": 0.75,
+        },
+        minimax_payload={"layout": layout},
+    )
+
+    expected_video = -patcher_helpers.minimax_model.unpatchify_video(
+        video_result, 1, 1, 1, 1, (1, 2, 2)
+    ).to(video.dtype)
+    expected_audio = -patcher_helpers.minimax_model.unpack_audio(audio_result).to(
+        audio.dtype
+    )
+    assert torch.equal(output[0], expected_video)
+    assert torch.equal(output[1], expected_audio)
+    assert received["nargs"] == 4
+
+
 def test_model_helper_adds_only_reversible_instance_patch(monkeypatch):
     class FakeH3:
         def _forward(self):

--- a/tests/test_patcher_nodes.py
+++ b/tests/test_patcher_nodes.py
@@ -534,18 +534,6 @@ def test_cached_forward_matches_current_core_audio_output_contract(monkeypatch):
     )
     video_result = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
     audio_result = torch.arange(1.0, 9.0).reshape(2, 4)
-    final_layer_args = {}
-
-    def final_layer(
-        hidden, t_emb, video_seg, audio_seg, sigma, sample_sigmas, shifts
-    ):
-        final_layer_args.update(
-            sigma=sigma,
-            sample_sigmas=sample_sigmas,
-            shifts=shifts,
-        )
-        return video_result, audio_result
-
     model = types.SimpleNamespace(
         patch_size=(1, 2, 2),
         sigma_shift_video=1.0,
@@ -560,7 +548,10 @@ def test_cached_forward_matches_current_core_audio_output_contract(monkeypatch):
         _cond_audio_rows=lambda payload, device: None,
         time_embedder=lambda values: values[:, None].expand(-1, 4),
         rope_freqs=lambda position_ids, device: torch.zeros((1, 1)),
-        final_layer=final_layer,
+        final_layer=lambda hidden, t_emb, video_seg, audio_seg: (
+            video_result,
+            audio_result,
+        ),
     )
     monkeypatch.setattr(
         patcher_helpers.minimax_model,
@@ -571,7 +562,6 @@ def test_cached_forward_matches_current_core_audio_output_contract(monkeypatch):
     video = torch.zeros((1, 1, 1, 2, 2), dtype=torch.float16)
     audio = torch.zeros((1, 4, 2, 1), dtype=torch.float16)
     context = torch.zeros((1, 1, 4), dtype=torch.float32)
-    sample_sigmas = torch.tensor([1.0, 0.5, 0.0])
 
     assert not hasattr(patcher_helpers.minimax_model, "time_shift_slope")
     output = patcher_helpers.minimax_h3_block_patch_forward(
@@ -579,11 +569,6 @@ def test_cached_forward_matches_current_core_audio_output_contract(monkeypatch):
         [video, audio],
         torch.tensor([500.0]),
         context,
-        transformer_options={
-            "sample_sigmas": sample_sigmas,
-            "minimax_h3_sigma_shift_video": 1.25,
-            "minimax_h3_sigma_shift_audio": 0.75,
-        },
         minimax_payload={"layout": layout},
     )
 
@@ -595,79 +580,6 @@ def test_cached_forward_matches_current_core_audio_output_contract(monkeypatch):
     )
     assert torch.equal(output[0], expected_video)
     assert torch.equal(output[1], expected_audio)
-    assert final_layer_args["sigma"].item() == pytest.approx(0.5)
-    assert final_layer_args["sample_sigmas"] is sample_sigmas
-    assert final_layer_args["shifts"] == (1.25, 0.75)
-
-
-def test_cached_forward_matches_current_core_final_layer_without_sigma_args(monkeypatch):
-    layout = types.SimpleNamespace(
-        signature=(1, 1, 2, 2, 1),
-        segments=[(0, 1, "text"), (1, 3, "audio"), (3, 4, "video")],
-        img_update=torch.ones(1, dtype=torch.bool),
-        audio_update=torch.ones(2, dtype=torch.bool),
-        seq_len=4,
-        position_ids=torch.zeros((4, 3)),
-    )
-    video_result = torch.tensor([[1.0, 2.0, 3.0, 4.0]])
-    audio_result = torch.arange(1.0, 9.0).reshape(2, 4)
-    received = {}
-
-    class CurrentFinalLayer(torch.nn.Module):
-        def forward(self, x, t_emb, video_seg, audio_seg):
-            received["nargs"] = 4
-            received["video_seg"] = video_seg
-            received["audio_seg"] = audio_seg
-            return video_result, audio_result
-
-    model = types.SimpleNamespace(
-        patch_size=(1, 2, 2),
-        sigma_shift_video=1.0,
-        sigma_shift_audio=1.0,
-        hidden_size=4,
-        use_adaln_curves=False,
-        blocks=[],
-        latents_dim=1,
-        video_patch_proj=lambda rows: rows,
-        audio_patch_proj=lambda rows: rows,
-        _cond_video_rows=lambda payload, device: None,
-        _cond_audio_rows=lambda payload, device: None,
-        time_embedder=lambda values: values[:, None].expand(-1, 4),
-        rope_freqs=lambda position_ids, device: torch.zeros((1, 1)),
-        final_layer=CurrentFinalLayer(),
-    )
-    monkeypatch.setattr(
-        patcher_helpers.minimax_model,
-        "rope_rotation_table",
-        lambda frequencies, dtype: frequencies,
-    )
-
-    video = torch.zeros((1, 1, 1, 2, 2), dtype=torch.float16)
-    audio = torch.zeros((1, 4, 2, 1), dtype=torch.float16)
-    context = torch.zeros((1, 1, 4), dtype=torch.float32)
-
-    output = patcher_helpers.minimax_h3_block_patch_forward(
-        model,
-        [video, audio],
-        torch.tensor([500.0]),
-        context,
-        transformer_options={
-            "sample_sigmas": torch.tensor([1.0, 0.5, 0.0]),
-            "minimax_h3_sigma_shift_video": 1.25,
-            "minimax_h3_sigma_shift_audio": 0.75,
-        },
-        minimax_payload={"layout": layout},
-    )
-
-    expected_video = -patcher_helpers.minimax_model.unpatchify_video(
-        video_result, 1, 1, 1, 1, (1, 2, 2)
-    ).to(video.dtype)
-    expected_audio = -patcher_helpers.minimax_model.unpack_audio(audio_result).to(
-        audio.dtype
-    )
-    assert torch.equal(output[0], expected_video)
-    assert torch.equal(output[1], expected_audio)
-    assert received["nargs"] == 4
 
 
 def test_model_helper_adds_only_reversible_instance_patch(monkeypatch):


### PR DESCRIPTION
## Summary
- MiniMax H3 cache/patch crashes on current ComfyUI because the patched forward still calls `FinalLayer` with `sigma`, `sample_sigmas`, and `shifts`.
- Current Core `FinalLayer.forward()` is `forward(self, x, t_emb, video_seg, audio_seg)`. Match that call.

Fixes #25

## Test plan
- [ ] `python tests/run_tests.py --group patcher` (37 passed locally)
- [ ] Run a MiniMax H3 workflow with UtilsCollection H3 cache/patch enabled on current ComfyUI
- [ ] Confirm sampling no longer fails with `FinalLayer.forward() takes 5 positional arguments but 8 were given`